### PR TITLE
Add ring buffer op to NNVM and Relay

### DIFF
--- a/include/tvm/relay/attrs/nn.h
+++ b/include/tvm/relay/attrs/nn.h
@@ -366,6 +366,14 @@ struct DenseAttrs : public tvm::AttrsNode<DenseAttrs> {
   }
 };
 
+struct ContribRingBufferAttrs : public tvm::AttrsNode<ContribRingBufferAttrs> {
+  int axis;
+
+  TVM_DECLARE_ATTRS(ContribRingBufferAttrs, "relay.attrs.ContribRingBufferAttrs") {
+    TVM_ATTR_FIELD(axis).set_default(0);
+  }
+};
+
 
 /*! \brief Attributes for upsampling operator */
 struct UpSamplingAttrs : public tvm::AttrsNode<UpSamplingAttrs> {

--- a/nnvm/python/nnvm/frontend/common.py
+++ b/nnvm/python/nnvm/frontend/common.py
@@ -36,7 +36,10 @@ def required_attr(attr, key, op_name):
 
 def parse_tshape(tshape):
     """Parse tshape in string."""
-    return [int(x.strip()) for x in tshape.strip('()').split(',')]
+    try:
+        return [int(x.strip()) for x in tshape.strip('()').split(',')]
+    except ValueError:
+        return [int(x.strip()) for x in tshape.strip('[]').split(',')]
 
 def parse_bool_str(attr, key, default='False'):
     """Parse bool string to boolean."""

--- a/nnvm/python/nnvm/frontend/mxnet.py
+++ b/nnvm/python/nnvm/frontend/mxnet.py
@@ -289,11 +289,6 @@ def _lrn(inputs, attrs):
     new_attrs['size'] = required_attr(attrs, 'nsize', 'lrn')
     return get_nnvm_op(op_name)(*inputs, **new_attrs)
 
-def _symbol_ring_buffer(inputs, attrs):
-    output = _get_nnvm_op('ring_buffer')(*inputs, **attrs)
-    return _sym._assign(inputs[1], output)
-
-
 def _copy(inputs, _):
     return _get_nnvm_op('copy')(inputs[0], **{})
 
@@ -393,8 +388,7 @@ _convert_map = {
     'expand_dims'   : _expand_dims,
     'LRN'           : _lrn,
     'ring_buffer'   : _symbol_ring_buffer,
-    'LinearRegressionOutput' : _copy,
-    'ring_buffer'   : _symbol_ring_buffer
+    'LinearRegressionOutput' : _copy
 }
 
 def _convert_symbol(op_name, inputs, attrs,

--- a/nnvm/python/nnvm/frontend/mxnet.py
+++ b/nnvm/python/nnvm/frontend/mxnet.py
@@ -328,6 +328,10 @@ def _argmin(inputs, attrs):
     new_attrs['keepdims'] = parse_bool_str(attrs, 'keepdims', default="False")
     return get_nnvm_op(op_name)(*inputs, **new_attrs)
 
+def _symbol_ring_buffer(inputs, attrs):
+    output = get_nnvm_op('ring_buffer')(*inputs, **attrs)
+    return _sym._assign(inputs[1], output)
+
 _identity_list = ['__add_scalar__', '__add_symbol__', '__div_scalar__',
                   '__div_symbol__', '__mul_scalar__', '__mul_symbol__',
                   '__pow_scalar__', '__rdiv_scalar__', '__rpow_scalar__',
@@ -389,7 +393,8 @@ _convert_map = {
     'expand_dims'   : _expand_dims,
     'LRN'           : _lrn,
     'ring_buffer'   : _symbol_ring_buffer,
-    'LinearRegressionOutput' : _copy
+    'LinearRegressionOutput' : _copy,
+    'ring_buffer'   : _symbol_ring_buffer
 }
 
 def _convert_symbol(op_name, inputs, attrs,

--- a/nnvm/python/nnvm/top/__init__.py
+++ b/nnvm/python/nnvm/top/__init__.py
@@ -9,6 +9,7 @@ from . import transform
 from . import reduction
 from . import vision
 from . import image
+from . import ring_buffer
 
 from .registry import OpPattern
 from .registry import register_compute, register_schedule, register_pattern

--- a/nnvm/python/nnvm/top/ring_buffer.py
+++ b/nnvm/python/nnvm/top/ring_buffer.py
@@ -1,0 +1,16 @@
+# pylint: disable=invalid-name, unused-argument
+"""Definition of ring buffer op"""
+from __future__ import absolute_import
+
+import topi
+import tvm
+from . import registry as reg
+
+@reg.register_compute('ring_buffer', level=100)
+def compute_ring_buffer(attrs, inputs, _):
+    return topi.nn.ring_buffer(inputs[0], inputs[1], axis=attrs.get_int('axis'))
+
+@reg.register_schedule('ring_buffer')
+def schedule_ring_buffer(_, outs, target):
+    with tvm.target.create(target):
+        return topi.generic.schedule_injective(outs)

--- a/nnvm/python/nnvm/top/ring_buffer.py
+++ b/nnvm/python/nnvm/top/ring_buffer.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # pylint: disable=invalid-name, unused-argument
 """Definition of ring buffer op"""
 from __future__ import absolute_import

--- a/nnvm/src/top/tensor/buffer_op.cc
+++ b/nnvm/src/top/tensor/buffer_op.cc
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 /*!
  *  Copyright (c) 2017 by Contributors
  * \file buffer_op.cc

--- a/nnvm/src/top/tensor/buffer_op.cc
+++ b/nnvm/src/top/tensor/buffer_op.cc
@@ -1,0 +1,94 @@
+/*!
+ *  Copyright (c) 2017 by Contributors
+ * \file buffer_op.cc
+ * \brief placeholder for ring buffer operator
+ */
+#include <nnvm/top/tensor.h>
+#include <nnvm/op.h>
+#include <nnvm/compiler/op_attr_types.h>
+#include <nnvm/compiler/util.h>
+#include "../op_common.h"
+#include "../elemwise_op_common.h"
+
+namespace nnvm {
+namespace top {
+using namespace tvm;
+using namespace nnvm::compiler;
+
+struct RingBufferParam : public dmlc::Parameter<RingBufferParam> {
+  int axis;
+  DMLC_DECLARE_PARAMETER(RingBufferParam) {
+    DMLC_DECLARE_FIELD(axis)
+      .describe("The axis along which to buffer previous inputs");
+  }
+};
+
+DMLC_REGISTER_PARAMETER(RingBufferParam);
+
+inline bool RingBufferShape(const NodeAttrs& attrs,
+                            std::vector<TShape>* in_attrs,
+                            std::vector<TShape>* out_attrs) {
+  CHECK_EQ(in_attrs->size(), 2U);
+  CHECK_EQ(out_attrs->size(), 1U);
+  const TShape& input_shape = in_attrs->at(0);
+  const TShape& buffer_shape = in_attrs->at(1);
+
+  const RingBufferParam& param = get<RingBufferParam>(attrs.parsed);
+  const size_t bufferAxis = static_cast<size_t>(param.axis < 0
+    ? static_cast<int>(buffer_shape.ndim()) + param.axis : param.axis);
+  CHECK_LT(bufferAxis, buffer_shape.ndim())
+    << "Buffer axis out of range: " << param.axis;
+  CHECK_EQ(buffer_shape.ndim(), input_shape.ndim())
+    << "buffer and input must have same number of dimensions, buffer_shape = "
+    << buffer_shape << ", input_shape = " << input_shape;
+  for (size_t i = 0; i < buffer_shape.ndim(); ++i) {
+    if (i != bufferAxis) {
+      CHECK_EQ(input_shape[i], buffer_shape[i])
+        << "Input shape inconsistent with buffer shape in dimension " << i;
+    }
+  }
+  CHECK_LE(input_shape[bufferAxis], buffer_shape[bufferAxis])
+    << "Input must be shorter than buffer in dimension " << param.axis;
+  NNVM_ASSIGN_OUTPUT_SHAPE(attrs, *out_attrs, 0, buffer_shape);
+
+  return true;
+}
+
+NNVM_REGISTER_OP(ring_buffer)
+.describe(R"code(Implements a ring buffer, in which a set number of past
+inputs are internally cached. The output of the buffer operator is the latest
+[length_buffer] outputs.)code" NNVM_ADD_FILELINE)
+.set_num_inputs(2)
+.set_num_outputs(1)
+.set_attr_parser(ParamParser<RingBufferParam>)
+.set_attr<FMutateInputs>(
+  "FMutateInputs", [](const NodeAttrs& attrs) {
+    return std::vector<uint32_t>{1};
+  })
+.set_attr<FInferShape>("FInferShape", RingBufferShape)
+.set_attr<FInferType>("FInferType", ElemwiseType<2, 1>)
+.set_attr<FCorrectLayout>(
+  "FCorrectLayout", [](const NodeAttrs& attrs,
+                       std::vector<Layout>* in_layouts,
+                       const std::vector<Layout>* last_in_layouts,
+                       std::vector<Layout>* out_layouts) {
+  NNVM_ASSIGN_LAYOUT(*in_layouts, 0, Layout("NCHW"));
+  return true;
+})
+.add_argument("data", "NDArray-or-Symbol", "Latest input")
+.add_argument("buffer", "NDArray-or-Symbol",
+              "Buffer storing latest [length_buffer] inputs")
+.add_arguments(RingBufferParam::__FIELDS__())
+.set_attr<FTVMCompute>(
+  "FTVMCompute", [](const NodeAttrs& attrs,
+                    const Array<Tensor>& inputs,
+                    const Array<Tensor>& out_info) {
+    /* dummy; will be replaced by a call to nnvm.top.register_compute() */
+    LOG(FATAL) << "Reached a dummy implementation; "
+               << "must supply a TVM implementation with nnvm.top.register_compute()";
+    return Array<Tensor>{ inputs[0] };
+})
+.set_support_level(1);
+
+}  // namespace top
+}  // namespace nnvm

--- a/python/tvm/relay/frontend/mxnet.py
+++ b/python/tvm/relay/frontend/mxnet.py
@@ -857,6 +857,11 @@ def _mx_rnn_layer(inputs, attrs):
     return ret
 
 
+def _mx_contrib_ring_buffer(inputs, attrs):
+    new_attrs = {}
+    new_attrs["axis"] = attrs.get_int("axis")
+    return _op.nn.contrib_ring_buffer(*inputs, **new_attrs)
+
 # Note: due to attribute conversion constraint
 # ops in the identity set must be attribute free
 _identity_list = [
@@ -1018,6 +1023,7 @@ _convert_map = {
     # TODO(tvm-tvm): support all operators.
     #
     # "broadcast_to",
+    "ring_buffer"       : _mx_contrib_ring_buffer,
 }
 
 # set identity list

--- a/python/tvm/relay/op/nn/_nn.py
+++ b/python/tvm/relay/op/nn/_nn.py
@@ -68,6 +68,17 @@ def schedule_dense(attrs, outputs, target):
 
 reg.register_pattern("nn.dense", reg.OpPattern.OUT_ELEMWISE_FUSABLE)
 
+@reg.register_compute('nn.contrib_ring_buffer', level=100)
+def compute_ring_buffer(attrs, inputs, out_type, target):
+    return [topi.nn.ring_buffer(inputs[0], inputs[1], axis=attrs.get_int('axis'))]
+
+@reg.register_schedule('nn.contrib_ring_buffer')
+def schedule_ring_buffer(attrs, outputs, target):
+    with target:
+        return topi.generic.schedule_injective(outputs)
+
+reg.register_pattern("nn.contrib_ring_buffer", OpPattern.OPAQUE)
+
 
 # batch_matmul
 @reg.register_compute("nn.batch_matmul")

--- a/python/tvm/relay/op/nn/nn.py
+++ b/python/tvm/relay/op/nn/nn.py
@@ -504,8 +504,8 @@ def dense(data, weight, units=None, out_dtype=""):
     """
     return _make.dense(data, weight, units, out_dtype)
 
-def contrib_ring_buffer(input, buffer, axis):
-    return _make.contrib_ring_buffer(input, buffer, axis)
+def contrib_ring_buffer(data, buffer, axis):
+    return _make.contrib_ring_buffer(data, buffer, axis)
 
 
 def relu(data):

--- a/python/tvm/relay/op/nn/nn.py
+++ b/python/tvm/relay/op/nn/nn.py
@@ -504,6 +504,9 @@ def dense(data, weight, units=None, out_dtype=""):
     """
     return _make.dense(data, weight, units, out_dtype)
 
+def contrib_ring_buffer(input, buffer, axis):
+    return _make.contrib_ring_buffer(input, buffer, axis)
+
 
 def relu(data):
     """Rectified linear unit.

--- a/python/tvm/relay/op/op_attrs.py
+++ b/python/tvm/relay/op/op_attrs.py
@@ -55,6 +55,11 @@ class DenseAttrs(Attrs):
 
 
 @register_relay_attr_node
+class ContribRingBufferAttrs(Attrs):
+    """Attributes for nn.contrib_ring_buffer"""
+
+
+@register_relay_attr_node
 class UpSamplingAttrs(Attrs):
     """Attributes for nn.upsampling"""
 

--- a/topi/python/topi/nn/__init__.py
+++ b/topi/python/topi/nn/__init__.py
@@ -20,3 +20,4 @@ from .bitserial_conv2d import *
 from .bitserial_dense import *
 from .l2_normalize import *
 from .batch_matmul import *
+from .buffer_op import *

--- a/topi/python/topi/nn/buffer_op.py
+++ b/topi/python/topi/nn/buffer_op.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 """Ring buffer op"""
 from __future__ import absolute_import as _abs
 import tvm

--- a/topi/python/topi/nn/buffer_op.py
+++ b/topi/python/topi/nn/buffer_op.py
@@ -1,0 +1,95 @@
+"""Ring buffer op"""
+from __future__ import absolute_import as _abs
+import tvm
+from ..util import equal_const_int
+from .. import tag
+
+@tvm.tag_scope(tag=tag.INJECTIVE+",ring_buffer")
+def ring_buffer(input, buffer, axis):
+    assert len(input.shape) == len(buffer.shape), \
+        'buffer and input must have same number of dimensions, ' + \
+        'buffer.shape = {}, input.shape = {}'.format(buffer.shape, input.shape)
+    assert axis >= 0 and axis < len(buffer.shape), 'buffer axis out of range'
+    for i in range(len(input.shape)):
+        if i == axis:
+            assert int(str(input.shape[i])) <= int(str(buffer.shape[i]))
+        else:
+            assert int(str(input.shape[i])) == int(str(buffer.shape[i]))
+
+    # for now only 4D and 5D are supported
+    assert len(buffer.shape) == 4 or len(buffer.shape) == 5
+
+    buflen = buffer.shape[axis]
+    input_size = input.shape[axis]
+
+    if len(buffer.shape) == 4:
+        if axis == 0:
+            return tvm.compute(buffer.shape,
+                               lambda i, j, k, l:
+                                   tvm.if_then_else(i < buflen - input_size,
+                                       buffer[i + input_size, j, k, l],
+                                       input[i - buflen + input_size, j, k, l]),
+                               name='new_buffer')
+        elif axis == 1:
+            return tvm.compute(buffer.shape,
+                               lambda i, j, k, l:
+                                   tvm.if_then_else(j < buflen - input_size,
+                                       buffer[i, j + input_size, k, l],
+                                       input[i, j - buflen + input_size, k, l]),
+                               name='new_buffer')
+        elif axis == 2:
+            return tvm.compute(buffer.shape,
+                               lambda i, j, k, l:
+                                   tvm.if_then_else(k < buflen - input_size,
+                                       buffer[i, j, k + input_size, l],
+                                       input[i, j, k - buflen + input_size, l]),
+                               name='new_buffer')
+        elif axis == 3:
+            return tvm.compute(buffer.shape,
+                               lambda i, j, k, l:
+                                   tvm.if_then_else(l < buflen - input_size,
+                                       buffer[i, j, k, l + input_size],
+                                       input[i, j, k, l - buflen + input_size]),
+                               name='new_buffer')
+        else:
+            assert False, "shouldn't get here"
+    elif len(buffer.shape) == 5:
+        if axis == 0:
+            return tvm.compute(buffer.shape,
+                               lambda i, j, k, l, m:
+                                   tvm.if_then_else(i < buflen - input_size,
+                                       buffer[i + input_size, j, k, l, m],
+                                       input[i - buflen + input_size, j, k, l, m]),
+                               name='new_buffer')
+        elif axis == 1:
+            return tvm.compute(buffer.shape,
+                               lambda i, j, k, l, m:
+                                   tvm.if_then_else(j < buflen - input_size,
+                                       buffer[i, j + input_size, k, l, m],
+                                       input[i, j - buflen + input_size, k, l, m]),
+                               name='new_buffer')
+        elif axis == 2:
+            return tvm.compute(buffer.shape,
+                               lambda i, j, k, l, m:
+                                   tvm.if_then_else(k < buflen - input_size,
+                                       buffer[i, j, k + input_size, l, m],
+                                       input[i, j, k - buflen + input_size, l, m]),
+                               name='new_buffer')
+        elif axis == 3:
+            return tvm.compute(buffer.shape,
+                               lambda i, j, k, l, m:
+                                   tvm.if_then_else(l < buflen - input_size,
+                                       buffer[i, j, k, l + input_size, m],
+                                       input[i, j, k, l - buflen + input_size, m]),
+                               name='new_buffer')
+        elif axis == 4:
+            return tvm.compute(buffer.shape,
+                               lambda i, j, k, l, m:
+                                   tvm.if_then_else(m < buflen - input_size,
+                                       buffer[i, j, k, l, m + input_size],
+                                       input[i, j, k, l, m - buflen + input_size]),
+                               name='new_buffer')
+        else:
+            assert False, "shouldn't get here"
+    else:
+        assert 'Only 4D and 5D supported'


### PR DESCRIPTION
The ring buffer lets you cache last X outputs of a previous layer.
[buffer_op_design.pdf](https://github.com/neo-ai/tvm/files/3332610/buffer_op_design.pdf)
