### PR TITLE
Fix TensorRT integration and add TRT tests to CI

### DIFF
--- a/cmake/modules/contrib/TensorRT.cmake
+++ b/cmake/modules/contrib/TensorRT.cmake
@@ -17,16 +17,20 @@
 
 # TensorRT Module
 
-if(IS_DIRECTORY ${USE_TENSORRT})
-    set(TENSORRT_ROOT_DIR ${USE_TENSORRT})
-    message(STATUS "Custom TensorRT path: " ${TENSORRT_ROOT_DIR})
-    set(TENSORRT_INCLUDE_DIR ${TENSORRT_ROOT_DIR}/include)
-    set(TENSORRT_LIB_DIR ${TENSORRT_ROOT_DIR}/lib)
+if(USE_TENSORRT)
+    if(IS_DIRECTORY ${USE_TENSORRT})
+        set(TENSORRT_ROOT_DIR ${USE_TENSORRT})
+    endif()
+    find_path(TENSORRT_INCLUDE_DIR NvInfer.h HINTS ${TENSORRT_ROOT_DIR} PATH_SUFFIXES include)
+    find_library(TENSORRT_LIB_DIR nvinfer HINTS ${TENSORRT_ROOT_DIR} PATH_SUFFIXES lib)
+    find_package_handle_standard_args(TENSORRT DEFAULT_MSG TENSORRT_INCLUDE_DIR TENSORRT_LIB_DIR)
+    if(NOT TENSORRT_FOUND)
+        message(ERROR "Could not find TensorRT.")
+    endif()
     file(GLOB TENSORRT_SRCS src/contrib/subgraph/*.cc)
     include_directories(${TENSORRT_INCLUDE_DIR})
     list(APPEND RUNTIME_SRCS ${TENSORRT_SRCS})
-    find_library(TENSORRT_NVINFER_LIBRARY nvinfer ${TENSORRT_LIB_DIR})
-    list(APPEND TVM_RUNTIME_LINKER_LIBS ${TENSORRT_NVINFER_LIBRARY})
+    list(APPEND TVM_RUNTIME_LINKER_LIBS ${TENSORRT_LIB_DIR})
     set_source_files_properties(${RUNTIME_GRAPH_SRCS}
             PROPERTIES COMPILE_DEFINITIONS "TVM_GRAPH_RUNTIME_TENSORRT")
 endif()

--- a/nnvm/python/nnvm/compiler/build_module.py
+++ b/nnvm/python/nnvm/compiler/build_module.py
@@ -335,7 +335,7 @@ def build(graph, target=None, shape=None, dtype="float32",
         graph = _annotate_graph(graph, device_target,
                                 AnnotationType.DEVICE_TARGET)
         # Apply optimization
-        graph = optimize(graph, shape, dtype, layout)
+        graph = optimize(graph, shape, dtype, layout, target)
 
         # Clear extra params without nodes.
         _remove_noref_params(params, graph)

--- a/nnvm/src/compiler/graph_compile.cc
+++ b/nnvm/src/compiler/graph_compile.cc
@@ -321,11 +321,15 @@ nnvm::Graph GraphCompile(const nnvm::Graph& g) {
     ret.attrs["device_index"] = std::make_shared<any>(std::move(device_vec));
   }
   // Setup module.
-  static const PackedFunc& fbuild = GetPackedFunc("nnvm.compiler.build_target");
-  tvm::runtime::Module module =
-      fbuild(tvm::Map<std::string, Array<tvm::LoweredFunc>>(
-                 tar_func_map.begin(), tar_func_map.end()),
-             "", target_host);
+  tvm::runtime::Module module;
+  // When using external accelerators such as TensorRT, there might not be any
+  // functions to compile in the graph. In that case, an empty module is used.
+  if (!tar_func_map.empty()) {
+    static const PackedFunc& fbuild = GetPackedFunc("nnvm.compiler.build_target");
+    module = fbuild(tvm::Map<std::string, Array<tvm::LoweredFunc>>(
+                        tar_func_map.begin(), tar_func_map.end()),
+                    "", target_host);
+  }
 
   ret.attrs["module"] = std::make_shared<any>(std::move(module));
   ret = nnvm::ApplyPass(ret, "PlanMemory");

--- a/tests/scripts/task_python_tensorrt.sh
+++ b/tests/scripts/task_python_tensorrt.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+set -u
+
+export PYTHONPATH=nnvm/python:python:topi/python
+export LD_LIBRARY_PATH="build:${LD_LIBRARY_PATH:-}"
+
+rm -rf python/tvm/*.pyc python/tvm/*/*.pyc python/tvm/*/*/*.pyc
+
+TVM_FFI=ctypes python3 -m nose -v tests/python/tensorrt


### PR DESCRIPTION
There was two issues preventing the TensorRT integration from working. These regressions seem to have been caused by merges from upstream ([this commit](https://github.com/neo-ai/tvm/commit/dc06e32c614d7af7bb19bd23db619bc1a29daef9)) which accidentally overwrote the original TRT integration code.
1. `nnvm/python/nnvm/compiler/build_module.py`: The `target` param was no longer being passed to `optimize`. The conditions in `optimize` would therefore always prevent TRT subgraphs from being partitioned. I have removed these extra conditions so they are not needed anyway.
2. `nnvm/src/compiler/graph_compile.cc`: When the entire graph is converted to one TRT subgraph, there is nothing left for nnvm to compile into a module. In that situation, `nnvm.compiler.build_target` would hit an assertion and cause a crash. So instead we create an empty module.

To prevent this from occurring again in the future, I've added the existing TRT tests to the CI. I had to create a new docker image with TRT in order to do this, currently it is located [here](https://cloud.docker.com/repository/docker/trevoram/tvm) and the dockerfile is at `docker/Dockerfile.ci_gpu_trt`.

Other changes:
* Added a check in tests to make sure TRT subgraphs are created.
* Improved TensorRT.cmake to search for system install in additional to manually specified path.
