### PR TITLE
add downcast_fp16 relay pass and test script

### DIFF
--- a/python/tvm/relay/__init__.py
+++ b/python/tvm/relay/__init__.py
@@ -55,6 +55,7 @@ from . import image
 from . import frontend
 from . import backend
 from . import quantize
+from . import neo
 
 # Dialects
 from . import qnn

--- a/python/tvm/relay/neo/__init__.py
+++ b/python/tvm/relay/neo/__init__.py
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#pylint: disable=wildcard-import, redefined-builtin
+"""FP 16 pass utilities."""
+from __future__ import absolute_import as _abs
+from .downcast_fp16 import *

--- a/python/tvm/relay/neo/downcast_fp16.py
+++ b/python/tvm/relay/neo/downcast_fp16.py
@@ -14,21 +14,18 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# pylint: disable=invalid-name,arguments-differ,no-else-return,unused-argument,missing-docstring
+# pylint: disable=unused-argument,pointless-string-statement
+"""Relay Downcast from Full-precision to Half-precision floating-point Pass"""
 from __future__ import absolute_import
 from ..expr_functor import ExprMutator
-from ..expr import Function, Call, Let, Var, GlobalVar, Constant, Tuple, TupleGetItem
+from ..expr import Function, Call, Var, Constant, TupleGetItem
 from .. import transform as _transform
 from .. import module as _module
 from .. import cast
-"""
-Relay Downcast from Full-precision to Half-precision floating-point Pass
-"""
 
 def downcast_fp16(func):
-    # get_valid_counts and non_max_suppression does not support fp16 so we create a filter list for them
-    filter_list = ['vision.get_valid_counts', 'vision.non_max_suppression']
-    """
+    # pylint: disable=line-too-long
+    """Downcast to fp16 mutator
     Parameters
     ---------
     graph: Function
@@ -38,22 +35,21 @@ def downcast_fp16(func):
     -------
     The graph after dowmcasting to half-precision floating-point.
     """
+    # get_valid_counts and non_max_suppression does not support fp16 so we create a filter list for them
+    filter_list = ['vision.get_valid_counts', 'vision.non_max_suppression']
     class DowncastMutator(ExprMutator):
+        """Downcast to fp16 mutator"""
         def visit_call(self, call):
-            dtype = 'float16'
-            if call.op.name in filter_list:
-                dtype = 'float32'
+            dtype = 'float32' if call.op.name in filter_list else 'float16'
             new_fn = self.visit(call.op)
             # Collec the original dtypes
             type_list = []
             if call.op.name in filter_list:
                 # For nms
                 for arg in call.args:
-                    if isinstance(arg, TupleGetItem):
-                        arg_tuple = arg.tuple_value
-                        if isinstance(arg_tuple, Call):
-                            tuple_types = arg_tuple.checked_type.fields
-                            type_list.append(tuple_types[arg.index].dtype)
+                    if isinstance(arg, TupleGetItem) and isinstance(arg.tuple_value, Call):
+                        tuple_types = arg.tuple_value.checked_type.fields
+                        type_list.append(tuple_types[arg.index].dtype)
                 if call.op.name == 'vision.get_valid_counts':
                     tuple_types = call.checked_type.fields
                     for cur_type in tuple_types:
@@ -63,33 +59,28 @@ def downcast_fp16(func):
             new_args = list()
             arg_idx = 0
             for arg in args:
-                if isinstance(arg, Var) or isinstance(arg, Constant):
+                if isinstance(arg, (Var, Constant)):
                     new_args.append(cast(arg, dtype=dtype))
                 else:
                     if call.op.name in filter_list:
-                        if isinstance(arg, TupleGetItem):
-                            if type_list[arg_idx] == 'int32':
-                                new_args.append(arg)
-                            else:
-                                new_args.append(cast(arg, dtype=dtype))
+                        if isinstance(arg, TupleGetItem) and type_list[arg_idx] == 'int32':
+                            new_args.append(arg)
                         else:
                             new_args.append(cast(arg, dtype=dtype))
                     else:
                         new_args.append(arg)
                 arg_idx += 1
-            if call.op.name in filter_list:
-                if call.op.name == 'vision.get_valid_counts':
-                    return Call(new_fn, new_args, call.attrs)
-                else:
-                    return cast(Call(new_fn, new_args, call.attrs), dtype='float16')
-            else:
-                return Call(new_fn, new_args, call.attrs)
+            if call.op.name in filter_list and call.op.name != 'vision.get_valid_counts':
+                return cast(Call(new_fn, new_args, call.attrs), dtype='float16')
+            return Call(new_fn, new_args, call.attrs)
 
     class UpcastMutator(ExprMutator):
+        """upcast output back to fp32 mutator"""
         def visit_call(self, call):
             return cast(call, dtype='float32')
 
     def infer_type(expr):
+        """A method to infer the type of an intermediate node in the relay graph"""
         mod = _module.Module.from_expr(expr)
         mod = _transform.InferType()(mod)
         entry = mod["main"]
@@ -102,4 +93,3 @@ def downcast_fp16(func):
     func = upcast_pass.visit(func)
     func = infer_type(func)
     return func
-

--- a/python/tvm/relay/neo/downcast_fp16.py
+++ b/python/tvm/relay/neo/downcast_fp16.py
@@ -1,0 +1,105 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name,arguments-differ,no-else-return,unused-argument,missing-docstring
+from __future__ import absolute_import
+from ..expr_functor import ExprMutator
+from ..expr import Function, Call, Let, Var, GlobalVar, Constant, Tuple, TupleGetItem
+from .. import transform as _transform
+from .. import module as _module
+from .. import cast
+"""
+Relay Downcast from Full-precision to Half-precision floating-point Pass
+"""
+
+def downcast_fp16(func):
+    # get_valid_counts and non_max_suppression does not support fp16 so we create a filter list for them
+    filter_list = ['vision.get_valid_counts', 'vision.non_max_suppression']
+    """
+    Parameters
+    ---------
+    graph: Function
+        The original graph.
+
+    Retruns
+    -------
+    The graph after dowmcasting to half-precision floating-point.
+    """
+    class DowncastMutator(ExprMutator):
+        def visit_call(self, call):
+            dtype = 'float16'
+            if call.op.name in filter_list:
+                dtype = 'float32'
+            new_fn = self.visit(call.op)
+            # Collec the original dtypes
+            type_list = []
+            if call.op.name in filter_list:
+                # For nms
+                for arg in call.args:
+                    if isinstance(arg, TupleGetItem):
+                        arg_tuple = arg.tuple_value
+                        if isinstance(arg_tuple, Call):
+                            tuple_types = arg_tuple.checked_type.fields
+                            type_list.append(tuple_types[arg.index].dtype)
+                if call.op.name == 'vision.get_valid_counts':
+                    tuple_types = call.checked_type.fields
+                    for cur_type in tuple_types:
+                        type_list.append(cur_type.dtype)
+
+            args = [self.visit(arg) for arg in call.args]
+            new_args = list()
+            arg_idx = 0
+            for arg in args:
+                if isinstance(arg, Var) or isinstance(arg, Constant):
+                    new_args.append(cast(arg, dtype=dtype))
+                else:
+                    if call.op.name in filter_list:
+                        if isinstance(arg, TupleGetItem):
+                            if type_list[arg_idx] == 'int32':
+                                new_args.append(arg)
+                            else:
+                                new_args.append(cast(arg, dtype=dtype))
+                        else:
+                            new_args.append(cast(arg, dtype=dtype))
+                    else:
+                        new_args.append(arg)
+                arg_idx += 1
+            if call.op.name in filter_list:
+                if call.op.name == 'vision.get_valid_counts':
+                    return Call(new_fn, new_args, call.attrs)
+                else:
+                    return cast(Call(new_fn, new_args, call.attrs), dtype='float16')
+            else:
+                return Call(new_fn, new_args, call.attrs)
+
+    class UpcastMutator(ExprMutator):
+        def visit_call(self, call):
+            return cast(call, dtype='float32')
+
+    def infer_type(expr):
+        mod = _module.Module.from_expr(expr)
+        mod = _transform.InferType()(mod)
+        entry = mod["main"]
+        return entry if isinstance(expr, Function) else entry.body
+
+    func = infer_type(func)
+    downcast_pass = DowncastMutator()
+    func = downcast_pass.visit(func)
+    upcast_pass = UpcastMutator()
+    func = upcast_pass.visit(func)
+    func = infer_type(func)
+    return func
+

--- a/tests/python/relay/test_neo_downcast_fp16.py
+++ b/tests/python/relay/test_neo_downcast_fp16.py
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import numpy as np
+import tvm
+from tvm import relay
+from tvm.relay.testing import resnet
+import time
+
+def test_downcast_fp16_resnet():
+    image_shape = (3,224,224)
+    net, params = resnet.get_workload(image_shape=image_shape, dtype='float32')
+    # float32 
+    with relay.build_config(opt_level=3):
+        graph, lib, params = relay.build(net, params=params, target='llvm')
+    
+    # float16
+    func = relay.neo.downcast_fp16(net['main'])
+    with relay.build_config(opt_level=3):
+        graph_fp16, lib_fp16, params_fp16 = relay.build(net, params=params, target='llvm')
+    
+    rt = tvm.contrib.graph_runtime.create(graph, lib, tvm.cpu())
+    rt.set_input(**params)
+    rt_fp16 = tvm.contrib.graph_runtime.create(graph_fp16, lib_fp16, tvm.cpu())
+    rt_fp16.set_input(**params_fp16)
+    for i in range(1000):
+        X = tvm.nd.array(np.random.random_sample(image_shape).astype('float32'))
+        rt.set_input('data', X)
+        rt_fp16.set_input('data', X)
+        
+        rt.run()
+        rt_fp16.run()
+        out = rt.get_output(0).asnumpy()
+        out_fp16 = rt.get_output(0).asnumpy()
+        np.testing.assert_equal(np.argmax(out, axis=1), np.argmax(out_fp16, axis=1))
+
+if __name__ == "__main__":
+    test_downcast_fp16_resnet()

--- a/tests/python/relay/test_neo_downcast_fp16.py
+++ b/tests/python/relay/test_neo_downcast_fp16.py
@@ -37,7 +37,7 @@ def test_downcast_fp16_resnet():
     rt.set_input(**params)
     rt_fp16 = tvm.contrib.graph_runtime.create(graph_fp16, lib_fp16, tvm.cpu())
     rt_fp16.set_input(**params_fp16)
-    for i in range(1000):
+    for i in range(100):
         X = tvm.nd.array(np.random.random_sample(image_shape).astype('float32'))
         rt.set_input('data', X)
         rt_fp16.set_input('data', X)


### PR DESCRIPTION
Thanks for contributing to TVM!   Please refer to guideline https://docs.tvm.ai/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/dmlc/tvm/blob/master/CONTRIBUTORS.md#reviewers).

RFC is here: https://discuss.tvm.ai/t/relay-automatic-fp16-downcasting/3952/2
Introduce a new relay pass which will automatically converting fp32 relay graph to fp16 graph. There is some issues in nms and get_valid_count so we remain fp32 at those two operators.

Accuracy has been checked for both image classification and object detection models.