### PR TITLE
[Frontend] [MXNet] make_loss operator support

### DIFF
--- a/python/tvm/relay/frontend/mxnet.py
+++ b/python/tvm/relay/frontend/mxnet.py
@@ -1098,6 +1098,7 @@ _identity_list = [
 
 _convert_map = {
     "_copy"                  : _rename(_op.copy),
+    "make_loss"              : _rename(_op.copy),
     "relu"                   : _rename(_op.nn.relu),
     "broadcast_add"          : _rename(_op.add),
     "broadcast_sub"          : _rename(_op.subtract),

--- a/python/tvm/relay/frontend/mxnet.py
+++ b/python/tvm/relay/frontend/mxnet.py
@@ -639,9 +639,8 @@ def _mx_tile(inputs, attrs):
     new_attrs["reps"] = attrs.get_int_tuple("reps")
     return _op.tile(inputs[0], **new_attrs)
 
-
+# pylint: disable=unused-argument
 def _mx_make_loss(inputs, attrs):
-    #in forward pass identity is returned for make_Loss
     return inputs[0]
 
 

--- a/python/tvm/relay/frontend/mxnet.py
+++ b/python/tvm/relay/frontend/mxnet.py
@@ -640,6 +640,11 @@ def _mx_tile(inputs, attrs):
     return _op.tile(inputs[0], **new_attrs)
 
 
+def _mx_make_loss(inputs, attrs):
+    #in forward pass identity is returned for make_Loss
+    return inputs[0]
+
+
 def _mx_take(inputs, attrs):
     assert len(inputs) == 2
     mode = attrs.get_str("mode", "clip")
@@ -1098,7 +1103,6 @@ _identity_list = [
 
 _convert_map = {
     "_copy"                  : _rename(_op.copy),
-    "make_loss"              : _rename(_op.copy),
     "relu"                   : _rename(_op.nn.relu),
     "broadcast_add"          : _rename(_op.add),
     "broadcast_sub"          : _rename(_op.subtract),
@@ -1228,6 +1232,7 @@ _convert_map = {
     "smooth_l1"     : _mx_smooth_l1,
     "_contrib_div_sqrt_dim": _mx_contrib_div_sqrt_dim,
     "one_hot"           : _mx_one_hot,
+    "make_loss": _mx_make_loss,
     # vision
     "_contrib_BilinearResize2D" : _mx_resize,
     "_contrib_MultiBoxPrior" : _mx_multibox_prior,

--- a/tests/python/frontend/mxnet/test_forward.py
+++ b/tests/python/frontend/mxnet/test_forward.py
@@ -200,6 +200,12 @@ def test_forward_ones_like():
     mx_sym = mx.sym.ones_like(data, dtype='float32')
     verify_mxnet_frontend_impl(mx_sym, (2, 3, 4), (2, 3, 4))
 
+def test_forward_make_loss():
+    data = mx.sym.var('data')
+    ones = mx.sym.ones(shape=(2, 3, 4), dtype='float32')
+    mx_sym = mx.sym.make_loss((data-ones)**2/2, dtype='float32')
+    verify_mxnet_frontend_impl(mx_sym, (2, 3, 4), (2, 3, 4))
+
 def test_forward_zeros_like():
     data = mx.sym.var('data')
     mx_sym = mx.sym.zeros_like(data, dtype='float32')

--- a/tests/python/frontend/mxnet/test_forward.py
+++ b/tests/python/frontend/mxnet/test_forward.py
@@ -995,3 +995,4 @@ if __name__ == '__main__':
     test_forward_convolution()
     test_forward_deconvolution()
     test_forward_cond()
+    test_forward_make_loss()


### PR DESCRIPTION
MXNet make_loss support.

In forward implementation, the MXNet make_loss function just creates an Identity op hence we have added identity mapping in the mxnet frontend.
https://github.com/apache/incubator-mxnet/blob/992c3c0dd90c0723de6934e826a49bad6569eeac/src/operator/make_loss-inl.h#L88
