### PR TITLE
[Relay/TRT] Support clip for TRT 4 using relu + eltwise

### DIFF
--- a/python/tvm/relay/tensorrt.py
+++ b/python/tvm/relay/tensorrt.py
@@ -182,9 +182,10 @@ def EnableTrt(mod, params=None, trt_version=None):
     assert len(trt_version) == 3
 
     # Apply passes required for TRT
-    mod = relay.transform.RemoveUnusedFunctions()(mod)
-    mod = relay.transform.InferType()(mod)
-    mod = relay.transform.ConvertLayout('NCHW')(mod)
+    seq = relay.transform.Sequential([relay.transform.RemoveUnusedFunctions(),
+                                      relay.transform.ConvertLayout('NCHW')])
+    with relay.transform.PassContext(opt_level=3):
+        mod = seq(mod)
     mod = PreprocessForTrt(mod)
     if params:
         # Bind params so that we can use FoldConstant.

--- a/src/relay/backend/contrib/tensorrt/enable_tensorrt.cc
+++ b/src/relay/backend/contrib/tensorrt/enable_tensorrt.cc
@@ -392,8 +392,8 @@ static const std::unordered_map<std::string, IsCompatibleFn>
         {"mean", ReduceOpChecker},
         {"contrib.adaptive_max_pool2d", AdapativePool2DOpChecker},
         {"contrib.adaptive_avg_pool2d", AdapativePool2DOpChecker},
+        {"clip", AlwaysChecker},
         // Ops which require TRT 5.1.5+
-        {"clip", TrtVersionChecker<5, 1, 5>},
         {"nn.leaky_relu", TrtVersionChecker<5, 1, 5>},
         {"sin", TrtVersionChecker<5, 1, 5>},
         {"cos", TrtVersionChecker<5, 1, 5>},

--- a/src/runtime/contrib/tensorrt/tensorrt_builder.cc
+++ b/src/runtime/contrib/tensorrt/tensorrt_builder.cc
@@ -92,6 +92,8 @@ GetOpConverters() {
   map->emplace("ceil", std::make_shared<UnaryOpConverter>());
   map->emplace("floor", std::make_shared<UnaryOpConverter>());
   map->emplace("strided_slice", std::make_shared<StridedSliceOpConverter>());
+#else
+  map->emplace("clip", std::make_shared<ClipLegacyOpConverter>());
 #endif
 #if TRT_VERSION_GE(6, 0, 1)
   map->emplace("image.resize", std::make_shared<ResizeOpConverter>());

--- a/tests/python/relay/test_tensorrt.py
+++ b/tests/python/relay/test_tensorrt.py
@@ -494,8 +494,8 @@ def test_tensorrt_integration(test_all_models=False):
     i_data = np.random.uniform(0, 1, input_shape).astype(dtype)
     for model in models:
         latency[model], res = test_model(model, i_data, input_shape, dtype, use_trt=True)
-        # _, ref_res = test_model(model, i_data, input_shape, dtype, use_trt=False, num_iteration=1)
-        # tvm.testing.assert_allclose(res.asnumpy(), ref_res.asnumpy(), rtol=1e-3, atol=1e-3)
+        _, ref_res = test_model(model, i_data, input_shape, dtype, use_trt=False, num_iteration=1)
+        tvm.testing.assert_allclose(res.asnumpy(), ref_res.asnumpy(), rtol=1e-3, atol=1e-3)
     
     for model in models:
         print(model, latency[model])


### PR DESCRIPTION
Allow clip op for TRT4 using other ops.

I also snuck in two small fixes:
* Had accidently disabled consistency check for integration tests. Those are enabled again. (test_tensorrt.py)
* Call ConvertLayout properly. (tensorrt.py)