### PR TITLE
Use add_definitions instead of set_source_file_properties for TRT

### DIFF
--- a/cmake/modules/contrib/TensorRT.cmake
+++ b/cmake/modules/contrib/TensorRT.cmake
@@ -43,8 +43,7 @@ if(USE_TENSORRT)
     list(APPEND RUNTIME_SRCS src/relay/backend/contrib/tensorrt/common_utils.cc)
 
     # Set defines
-    set_source_files_properties(${RUNTIME_GRAPH_SRCS}
-            PROPERTIES COMPILE_DEFINITIONS "TVM_GRAPH_RUNTIME_TENSORRT")
+    add_definitions(-DTVM_GRAPH_RUNTIME_TENSORRT)
 endif()
 # TensorRT Codegen only. This can be enabled independently of USE_TENSORRT to
 # enable compilation of TensorRT modules without requiring TensorRT to be
@@ -56,9 +55,4 @@ if(USE_TENSORRT_CODEGEN)
     file(GLOB TENSORRT_RELAY_CONTRIB_SRC src/relay/backend/contrib/tensorrt/*.cc)
     list(APPEND COMPILER_SRCS ${TENSORRT_RELAY_CONTRIB_SRC})
     list(APPEND COMPILER_SRCS src/runtime/contrib/tensorrt/tensorrt_module.cc)
-    # If runtime is enabled also, set flag for compiler srcs
-    if(USE_TENSORRT)
-        set_source_files_properties(${COMPILER_SRCS}
-                PROPERTIES COMPILE_DEFINITIONS "TVM_GRAPH_RUNTIME_TENSORRT")
-    endif()
 endif()


### PR DESCRIPTION
`set_source_file_properties` appears to remove existing definitions set by cmake files. In this case, using it to define `TVM_GRAPH_RUNTIME_TENSORRT` removed the `DMLC_ENABLE_RTTI=0` definition set earlier by cmake. This caused DMLC to compile incorrectly when `USE_TENSORRT` is enabled.

Fix by using `add_definitions` to set `-DTVM_GRAPH_RUNTIME_TENSORRT`.