### PR TITLE
[Frontend] [Tensorflow] ReadVariableOp operator

### DIFF
--- a/python/tvm/relay/frontend/tensorflow.py
+++ b/python/tvm/relay/frontend/tensorflow.py
@@ -2099,9 +2099,10 @@ class GraphProto(object):
         missing_operators = self._parse_import_prerequisites(graph)
 
         if missing_operators:
-            # TODO: Add check for other operators which are removed when graph is freezed
-            # Or we can try to freeze the graph and in process remove the operators which
-            # are not needed for inference
+            # TODO: ReadVariableOp gets removed when graph is frozen.
+            # Add list of other operators as well which get removed and are not needed
+            # for inference.
+            # Other approach is instead of raising error, we can freeze the graph.
             if 'ReadVariableOp' in missing_operators:
                 raise Exception("Found ReadVariableOp operator in the graph. "
                                 "Graph is not frozen. Provide a frozen graph.")

--- a/python/tvm/relay/frontend/tensorflow.py
+++ b/python/tvm/relay/frontend/tensorflow.py
@@ -2099,8 +2099,15 @@ class GraphProto(object):
         missing_operators = self._parse_import_prerequisites(graph)
 
         if missing_operators:
-            raise NotImplementedError( \
-                "The following operators are not implemented: {}".format(missing_operators))
+            # TODO: Add check for other operators which are removed when graph is freezed
+            # Or we can try to freeze the graph and in process remove the operators which
+            # are not needed for inference
+            if 'ReadVariableOp' in missing_operators:
+                raise Exception("Found ReadVariableOp operator in the graph. "
+                                "Graph is not frozen. Provide a frozen graph.")
+            else:
+                raise NotImplementedError( \
+                    "The following operators are not implemented: {}".format(missing_operators))
 
         control_flow_node_map = defaultdict(set)
         for node in graph.node:

--- a/tests/python/frontend/tensorflow/test_forward.py
+++ b/tests/python/frontend/tensorflow/test_forward.py
@@ -1001,7 +1001,7 @@ def _test_variable(data):
     size = input_tensor.shape.dims[1]
     with variable_scope.variable_scope("linear", reuse=None):
         w = variable_scope.get_variable(
-            "w", shape=[size, size], dtype=input_tensor.dtype, use_resource=True)
+            "w", shape=[size, size], dtype=input_tensor.dtype)
     math_ops.matmul(input_tensor, w)
 
     compare_tf_with_tvm(data, 'Placeholder:0', 'MatMul:0',
@@ -2865,7 +2865,6 @@ def test_placeholder():
         compare_tf_with_tvm([in_data1, in_data2], ['place1:0', 'in2:0'], 'out2:0',
                             init_global_variables=True)
 
-
 #######################################################################
 # OneHot
 # ----------------------
@@ -3038,3 +3037,6 @@ if __name__ == '__main__':
     test_forward_where()
     test_forward_matmul()
     test_forward_batch_matmul()
+
+    # Internal misc. ops
+    test_read_variable_op()

--- a/tests/python/frontend/tensorflow/test_forward.py
+++ b/tests/python/frontend/tensorflow/test_forward.py
@@ -994,7 +994,7 @@ def test_forward_reduce():
 
 def _test_variable(data):
     """ One iteration of a variable """
-    
+
     tf.reset_default_graph()
     input_op = array_ops.placeholder(shape=data.shape, dtype=data.dtype)
     input_tensor = array_ops.reshape(input_op, data.shape)

--- a/tests/python/frontend/tensorflow/test_forward.py
+++ b/tests/python/frontend/tensorflow/test_forward.py
@@ -994,6 +994,7 @@ def test_forward_reduce():
 
 def _test_variable(data):
     """ One iteration of a variable """
+    
     tf.reset_default_graph()
     input_op = array_ops.placeholder(shape=data.shape, dtype=data.dtype)
     input_tensor = array_ops.reshape(input_op, data.shape)

--- a/tests/python/frontend/tensorflow/test_forward.py
+++ b/tests/python/frontend/tensorflow/test_forward.py
@@ -36,6 +36,7 @@ from distutils.version import LooseVersion
 import tvm
 from tvm import relay
 import tvm.relay.testing.tf as tf_testing
+import pytest
 
 #######################################################################
 # Generic run functions for TVM & tensorflow
@@ -993,7 +994,6 @@ def test_forward_reduce():
 
 def _test_variable(data):
     """ One iteration of a variable """
-
     tf.reset_default_graph()
     input_op = array_ops.placeholder(shape=data.shape, dtype=data.dtype)
     input_tensor = array_ops.reshape(input_op, data.shape)
@@ -1001,7 +1001,7 @@ def _test_variable(data):
     size = input_tensor.shape.dims[1]
     with variable_scope.variable_scope("linear", reuse=None):
         w = variable_scope.get_variable(
-            "w", shape=[size, size], dtype=input_tensor.dtype)
+            "w", shape=[size, size], dtype=input_tensor.dtype, use_resource=True)
     math_ops.matmul(input_tensor, w)
 
     compare_tf_with_tvm(data, 'Placeholder:0', 'MatMul:0',
@@ -1011,6 +1011,62 @@ def _test_variable(data):
 def test_forward_variable():
     """Variable type op test"""
     _test_variable(np.random.uniform(size=(32, 100)).astype('float32'))
+
+
+def test_read_variable_op():
+    """ Read Variable op test """
+    tf.reset_default_graph()
+    data = np.random.uniform(size=(32, 100)).astype('float32')
+    input_tensor = array_ops.placeholder(shape=data.shape, dtype=data.dtype)
+
+    size = input_tensor.shape.dims[1]
+    var_data = np.random.uniform(-5, 5, size=[size, size]).astype(np.float32)
+    input_var = tf.Variable(var_data, name='var1', use_resource=True)
+    math_ops.matmul(input_tensor, input_var)
+
+    out_name = ['MatMul:0']
+    out_node = ['MatMul']
+    in_name = ['Placeholder:0']
+    in_node = ['Placeholder']
+    in_data = [data]
+
+    with tf.Session() as sess:
+        sess.run(variables.global_variables_initializer())
+
+        final_graph_def = sess.graph.as_graph_def(add_shapes=True)
+        tf_output = run_tf_graph(sess, in_data, in_name, out_name)
+
+        shape_dict = {e: i.shape for e, i in zip(in_name, in_data)}
+        with pytest.raises(Exception) as exexcinfo:
+            mod, params = relay.frontend.from_tensorflow(final_graph_def,
+                                                         layout=None,
+                                                         shape=shape_dict,
+                                                         outputs=None)
+
+        assert exexcinfo.value.args[0] == "Found ReadVariableOp operator in the graph. " \
+                                          "Graph is not frozen. Provide a frozen graph."
+
+        # Now convert the variables to constant and run again on the tensorflow graph
+        final_graph_def = tf.graph_util.convert_variables_to_constants(
+            sess,
+            sess.graph.as_graph_def(add_shapes=True),
+            out_node,
+        )
+
+        for device in ["llvm", "cuda"]:
+            ctx = tvm.context(device, 0)
+            if not ctx.exist:
+                print("Skip because %s is not enabled" % device)
+                continue
+
+            tvm_output = run_tvm_graph(final_graph_def, in_data, in_node,
+                                       target=device, out_names=out_name,
+                                       num_output=len(out_name))
+            for i in range(len(tf_output)):
+                tvm.testing.assert_allclose(
+                    tf_output[i], tvm_output[i], atol=1e-5, rtol=1e-5)
+
+        sess.close()
 
 
 #######################################################################
@@ -2808,6 +2864,7 @@ def test_placeholder():
 
         compare_tf_with_tvm([in_data1, in_data2], ['place1:0', 'in2:0'], 'out2:0',
                             init_global_variables=True)
+
 
 #######################################################################
 # OneHot

--- a/tests/python/frontend/tensorflow/test_forward.py
+++ b/tests/python/frontend/tensorflow/test_forward.py
@@ -1046,7 +1046,7 @@ def test_read_variable_op():
         assert exexcinfo.value.args[0] == "Found ReadVariableOp operator in the graph. " \
                                           "Graph is not frozen. Provide a frozen graph."
 
-        # Now convert the variables to constant and run again on the tensorflow graph
+        # Now convert the variables to constant and run inference on the converted graph
         final_graph_def = tf.graph_util.convert_variables_to_constants(
             sess,
             sess.graph.as_graph_def(add_shapes=True),


### PR DESCRIPTION
The ReadVariableOp gets eliminated when you freeze the TensorFlow graph and is not needed for the inference.
https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/framework/graph_util_impl.py#L464

If we find a ReadVariableOp in a TF graph, we error out and ask for a frozen graph.

TODO - 
Another approach is to freeze the unfrozen graph in from_tensorflow API itself.
