### PR TITLE
Fix load serialized runtime module after rebase

### DIFF
--- a/src/relay/backend/contrib/tensorrt/README
+++ b/src/relay/backend/contrib/tensorrt/README
@@ -36,7 +36,7 @@ with open('compiled.json', 'r') as f_graph_json:
   graph = f_graph_json.read()
 with open('compiled.params', 'rb') as f_params:
   params = tvm.relay.load_param_dict(f_params.read())
-lib = tvm.module.load("compiled.tensorrt")
+lib = tvm.runtime.load_module("compiled.tensorrt")
 ```
 
 6. Run inference. The first invocation will trigger creation of the TensorRT engine. This could take up to a few minutes.

--- a/src/runtime/contrib/tensorrt/tensorrt_module.cc
+++ b/src/runtime/contrib/tensorrt/tensorrt_module.cc
@@ -208,12 +208,12 @@ TVM_REGISTER_GLOBAL("tvm.contrib.tensorrt.create")
   *rv = TensorRTModuleCreate(args[0]);
 });
 
-TVM_REGISTER_GLOBAL("module.loadfile_tensorrt")
+TVM_REGISTER_GLOBAL("runtime.module.loadfile_tensorrt")
 .set_body([](TVMArgs args, TVMRetValue* rv) {
   *rv = TensorRTModule::LoadFromFile(args[0]);
 });
 
-TVM_REGISTER_GLOBAL("module.loadbinary_tensorrt")
+TVM_REGISTER_GLOBAL("runtime.module.loadbinary_tensorrt")
 .set_body_typed(TensorRTModule::LoadFromBinary);
 
 }  // namespace runtime

--- a/tests/python/relay/test_tensorrt.py
+++ b/tests/python/relay/test_tensorrt.py
@@ -509,7 +509,6 @@ def test_tensorrt_serialize():
     mod, params = relay.frontend.from_mxnet(block, shape={'data': (1, 3, 224, 224)}, dtype='float32')
     # Compile
     mod = relay.tensorrt.EnableTrt(mod, params)
-    assert mod['main'].attrs and mod['main'].attrs.Compiler == 'tensorrt'
     with relay.build_config(opt_level=2, disabled_pass={"SimplifyInference"}):
         graph, lib, params = relay.build(mod, "cuda")
     # Serialize
@@ -523,7 +522,7 @@ def test_tensorrt_serialize():
         graph = f_graph_json.read()
     with open('compiled.params', 'rb') as f_params:
         params = bytearray(f_params.read())
-    lib = tvm.runtime.load("compiled.tensorrt")
+    lib = tvm.runtime.load_module("compiled.tensorrt")
     # Run
     mod = graph_runtime.create(graph, lib, ctx=tvm.gpu(0))
     mod.load_params(params)


### PR DESCRIPTION
Just realized I missed this change in last PR: https://github.com/neo-ai/tvm/pull/92