### PR TITLE
[Runtime] Enable set_output in GraphRuntime

### DIFF
--- a/python/tvm/contrib/graph_runtime.py
+++ b/python/tvm/contrib/graph_runtime.py
@@ -133,6 +133,7 @@ class GraphModule(object):
         self.module = module
         self._set_input = module["set_input"]
         self._run = module["run"]
+        self._set_output = module["set_output"]
         self._get_output = module["get_output"]
         self._get_input = module["get_input"]
         self._get_num_outputs = module["get_num_outputs"]
@@ -162,6 +163,19 @@ class GraphModule(object):
             keys.sort(key=lambda x: -np.prod(params[x].shape))
             for k in keys:
                 self._get_input(k).copyfrom(params[k])
+
+    def set_output(self, index, out):
+        """Set index-th output to out
+
+        Parameters
+        ----------
+        index : int
+            The output index
+
+        out : NDArray
+            The output array container
+        """
+        return self._set_output(index, out)
 
     def run(self, **input_dict):
         """Run forward execution of the graph

--- a/src/runtime/graph/graph_runtime.cc
+++ b/src/runtime/graph/graph_runtime.cc
@@ -156,6 +156,31 @@ void GraphRuntime::SetInputZeroCopy(int index, DLTensor* data_ref) {
   }
 }
 /*!
+ * \brief set index-th output to the graph.
+ * \param index The output index.
+ * \param data_ref The output data that is written.
+ */
+void GraphRuntime::SetOutput(int index, DLTensor* data_out) {
+  CHECK_LT(static_cast<size_t>(index), outputs_.size());
+  uint32_t eid = this->entry_id(outputs_[index]);
+  const DLTensor* old_t = data_entry_[eid].operator->();
+
+  // check the consistency of input
+  CHECK_EQ(data_alignment_[eid], details::GetDataAlignment(*data_out));
+  CHECK_EQ(reinterpret_cast<size_t>(data_out->data) % kAllocAlignment, 0);
+  CHECK_EQ(old_t->ndim, static_cast<size_t>(data_out->ndim));
+  CHECK_EQ(old_t->ctx.device_type, data_out->ctx.device_type);
+  CHECK_EQ(old_t->ctx.device_id, data_out->ctx.device_id);
+  for (auto i = 0; i < data_out->ndim; ++i) {
+    CHECK_EQ(old_t->shape[i], data_out->shape[i]);
+  }
+  old_t = data_out;
+  // Update the data pointer for each argument of each op
+  for (DLTensor* t : input_dltensors_[eid]) {
+    t->data = data_out->data;
+  }
+}
+/*!
  * \brief Get the number of outputs
  *
  * \return The number of outputs from graph.
@@ -465,6 +490,10 @@ PackedFunc GraphRuntime::GetFunction(
       } else {
         this->SetInputZeroCopy(args[0], args[1]);
       }
+    });
+  } else if (name == "set_output") {
+    return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {
+      this->SetOutput(args[0], args[1]);
     });
   } else if (name == "get_output") {
     return PackedFunc([sptr_to_self, this](TVMArgs args, TVMRetValue* rv) {

--- a/src/runtime/graph/graph_runtime.cc
+++ b/src/runtime/graph/graph_runtime.cc
@@ -176,6 +176,8 @@ void GraphRuntime::SetOutput(int index, DLTensor* data_out) {
   }
 
   const_cast<DLTensor*>(old_t)->data = data_out->data;
+  const_cast<DLTensor*>(old_t)->strides = data_out->strides;
+  const_cast<DLTensor*>(old_t)->byte_offset = data_out->byte_offset;
 }
 /*!
  * \brief Get the number of outputs

--- a/src/runtime/graph/graph_runtime.cc
+++ b/src/runtime/graph/graph_runtime.cc
@@ -174,11 +174,8 @@ void GraphRuntime::SetOutput(int index, DLTensor* data_out) {
   for (auto i = 0; i < data_out->ndim; ++i) {
     CHECK_EQ(old_t->shape[i], data_out->shape[i]);
   }
-  old_t = data_out;
-  // Update the data pointer for each argument of each op
-  for (DLTensor* t : input_dltensors_[eid]) {
-    t->data = data_out->data;
-  }
+
+  const_cast<DLTensor*>(old_t)->data = data_out->data;
 }
 /*!
  * \brief Get the number of outputs
@@ -377,14 +374,14 @@ void GraphRuntime::SetupOpExecs() {
   for (uint32_t nid = 0; nid < this->GetNumOfNodes(); ++nid) {
     const auto& inode = nodes_[nid];
     if (inode.op_type == "null") continue;
-    std::vector<DLTensor> args;
+    std::vector<DLTensor*> args;
     for (const auto& e : inode.inputs) {
       uint32_t eid = this->entry_id(e);
-      args.push_back(*(data_entry_[eid].operator->()));
+      args.push_back(const_cast<DLTensor*>(data_entry_[eid].operator->()));
     }
     for (uint32_t index = 0; index < inode.param.num_outputs; ++index) {
       uint32_t eid = this->entry_id(nid, index);
-      args.push_back(*(data_entry_[eid].operator->()));
+      args.push_back(const_cast<DLTensor*>(data_entry_[eid].operator->()));
     }
 
     if (inode.op_type == "tvm_op") {
@@ -417,7 +414,7 @@ void GraphRuntime::SetupOpExecs() {
 
 std::pair<std::function<void()>, std::shared_ptr<GraphRuntime::OpArgs> > GraphRuntime::CreateTVMOp(
     const TVMOpParam& param,
-    const std::vector<DLTensor>& args,
+    const std::vector<DLTensor*>& args,
     size_t num_inputs) {
   std::shared_ptr<GraphRuntime::OpArgs> arg_ptr = std::make_shared<GraphRuntime::OpArgs>();
   // setup address.
@@ -427,7 +424,7 @@ std::pair<std::function<void()>, std::shared_ptr<GraphRuntime::OpArgs> > GraphRu
   }
   for (size_t i = 0; i < arg_ptr->args.size(); ++i) {
     TVMValue v;
-    DLTensor* t = &arg_ptr->args[i];
+    DLTensor* t = arg_ptr->args[i];
     v.v_handle = t;
     arg_ptr->arg_values.push_back(v);
     arg_ptr->arg_tcodes.push_back(kTVMDLTensorHandle);

--- a/src/runtime/graph/graph_runtime.h
+++ b/src/runtime/graph/graph_runtime.h
@@ -72,7 +72,7 @@ struct TVMOpParam {
  */
 class TVM_DLL GraphRuntime : public ModuleNode {
   struct OpArgs {
-    std::vector<DLTensor> args;
+    std::vector<DLTensor*> args;
     std::vector<TVMValue> arg_values;
     std::vector<int> arg_tcodes;
     std::vector<int64_t> shape_data;
@@ -425,7 +425,7 @@ class TVM_DLL GraphRuntime : public ModuleNode {
    * \return The created executor.
    */
   std::pair<std::function<void()>, std::shared_ptr<OpArgs> > CreateTVMOp(
-      const TVMOpParam& attrs, const std::vector<DLTensor>& args,
+      const TVMOpParam& attrs, const std::vector<DLTensor*>& args,
       size_t num_inputs);
   // Get node entry index.
   uint32_t entry_id(uint32_t nid, uint32_t index) const {

--- a/src/runtime/graph/graph_runtime.h
+++ b/src/runtime/graph/graph_runtime.h
@@ -142,6 +142,12 @@ class TVM_DLL GraphRuntime : public ModuleNode {
    */
   void SetInputZeroCopy(int index, DLTensor* data_ref);
   /*!
+   * \brief set index-th output to the graph
+   * \param index The output index.
+   * \param data_ref The output data that is written.
+   */
+  void SetOutput(int index, DLTensor* data_out);
+  /*!
    * \brief Get the number of outputs
    *
    * \return The number of outputs from graph.

--- a/tests/cpp/relay_build_module_test.cc
+++ b/tests/cpp/relay_build_module_test.cc
@@ -159,6 +159,15 @@ TEST(Relay, BuildModule) {
   for (int i = 0; i < 6; ++i) {
     CHECK_LT(fabs(pY3[i] - (i + (i + 3) + (i + 4))), 1e-4);
   }
+  // attach an output and run it again
+  auto D = tvm::runtime::NDArray::Empty({2, 3}, {kDLFloat, 32, 1}, {kDLCPU, 0});
+  auto pD = (float*)D.ToDLPack()->dl_tensor.data;
+  auto set_output_f = run_mod.GetFunction("set_output", false);
+  set_output_f(0, &D.ToDLPack()->dl_tensor);
+  run_f();
+  for (int i = 0; i < 6; ++i) {
+    CHECK_LT(fabs(pD[i] - (i + (i + 3) + (i + 4))), 1e-4);
+  }
 }
 
 TEST(Relay, GetExprRefCount) {


### PR DESCRIPTION
To add a function in GraphRuntime which enables redirecting the result of calculation to some pre-allocated memory without copying the data.
