### PR TITLE
[TRT] Improvements and bug fixes for heterogeneous TRT

### DIFF
--- a/src/runtime/contrib/tensorrt/tensorrt_builder.cc
+++ b/src/runtime/contrib/tensorrt/tensorrt_builder.cc
@@ -151,6 +151,9 @@ void TensorRTBuilder::ProcessOutputs(const Expr& expr) {
     if (out_tensor->isNetworkOutput()) {
       LOG(WARNING) << output_name << " is a duplicate output.";
       out_tensor = network_->addIdentity(*out_tensor)->getOutput(0);
+    } else if (out_tensor->isNetworkInput()) {
+      LOG(WARNING) << output_name << " is also an input.";
+      out_tensor = network_->addIdentity(*out_tensor)->getOutput(0);
     }
     out_tensor->setName(output_name.c_str());
     network_output_names_.push_back(output_name);


### PR DESCRIPTION
* Make parsing of padding from relay more robust and consistent by adding helper method to op converters.
* Support output_padding on conv2d_transpose op.
* Pad op had CHECK preventing padding on batch dimension even when in explicit batch mode which was incorrect.
* Partitioning can create input in a subgraph which are not actually used. Until this is fixed, I added a workaround to prevent a TRT error. There will be an additional memcpy here until we fix the partitioning.
* Cached trt engine now includes "fp16" in the key name to distinguish between engines created for different precisions
* Deallocate serialized relay graph after it is converted to TRT.