### PR TITLE
[TRT] Fix TRT Performance caused by using explicit batch mode

### DIFF
--- a/python/tvm/relay/tensorrt.py
+++ b/python/tvm/relay/tensorrt.py
@@ -26,6 +26,7 @@ from tvm.relay.build_module import bind_params_by_name
 from tvm.relay import op as reg
 from tvm.relay.transform import _ffi_api
 from tvm.relay.expr_functor import ExprMutator
+import numpy as np
 
 
 class LegalizeLayoutTranform(ExprMutator):
@@ -131,11 +132,14 @@ def _register_external_op_helper_func(op_name, func, trt_version):
         return func(attrs, args, op_name, trt_version)
     return _func_wrapper
 
-def register_tensorrt_annotations(trt_version):
+def register_tensorrt_annotations(trt_version, use_implicit_batch=True):
     if hasattr(register_tensorrt_annotations, "registered"):
         # Can't register annotations more than once.
         return
     register_tensorrt_annotations.registered = True
+    if not use_implicit_batch and trt_version >= (6, 0, 1):
+        print("Explicit batch mode only available for TRT 6+")
+        use_implicit_batch = True
     # Ops which are always supported
     _register_external_op_helper("nn.relu")
     _register_external_op_helper("sigmoid")
@@ -185,7 +189,7 @@ def register_tensorrt_annotations(trt_version):
         if any([x.checked_type.dtype != "float32" for x in args]):
             print("Only float32 inputs are supported for TensorRT.")
             return False
-        if trt_version < (6, 0, 1) and int(attrs.axis) == 0:
+        if use_implicit_batch and int(attrs.axis) == 0:
             print("nn.softmax: can't modify batch dimension.")
             return False
         return True
@@ -288,7 +292,7 @@ def register_tensorrt_annotations(trt_version):
         if any([x.checked_type.dtype != "float32" for x in args]):
             print("Only float32 inputs are supported for TensorRT.")
             return False
-        if trt_version < (6, 0, 1) and int(attrs.axis) == 0:
+        if use_implicit_batch and int(attrs.axis) == 0:
             print("expand_dims: can't modify batch dimension.")
             return False
         return True
@@ -301,7 +305,7 @@ def register_tensorrt_annotations(trt_version):
         if not attrs.axis:
             print("squeeze: must explicitly set axis.")
             return False
-        if trt_version < (6, 0, 1) and any([axis == 0 for axis in map(int, attrs.axis)]):
+        if use_implicit_batch and any([axis == 0 for axis in map(int, attrs.axis)]):
             print("squeeze: can't modify batch dimension.")
             return False
         return True
@@ -311,7 +315,7 @@ def register_tensorrt_annotations(trt_version):
         if any([x.dtype != "float32" for x in args[0].checked_type.fields]):
             print("Only float32 inputs are supported for TensorRT.")
             return False
-        if trt_version >= (6, 0, 1):
+        if not use_implicit_batch:
             return True
         if int(attrs.axis) == 0:
             print("concatenate: can't modify batch dimension.")
@@ -350,7 +354,7 @@ def register_tensorrt_annotations(trt_version):
         if any([x.checked_type.dtype != "float32" for x in args]):
             print("Only float32 inputs are supported for TensorRT.")
             return False
-        if trt_version < (6, 0, 1) and int(attrs.axes[0]) != 0:
+        if use_implicit_batch and int(attrs.axes[0]) != 0:
             print("transpose: can't modify batch dimension.")
             return False
         return True
@@ -363,6 +367,26 @@ def register_tensorrt_annotations(trt_version):
         if any([x < -1 for x in map(int, attrs.newshape)]):
             print("reshape: new shape dims must be explicit.")
             return False
+        if use_implicit_batch:
+            shape = list(map(int, args[0].checked_type.shape))
+            new_shape = list(map(int, attrs.newshape))
+            if len(new_shape) == 0 or len(shape) == 0:
+                print("reshape: Can't reshape to or from scalar.")
+                return False
+            # TRT cannot modify batch dimension.
+            original_volume = np.prod(shape)
+            # First, resolve 0.
+            for i in range(len(new_shape)):
+                if new_shape[i] == 0:
+                    new_shape[i] = shape[i]
+            # Resolve -1.
+            for i in range(len(new_shape)):
+                if new_shape[i] == -1:
+                    new_shape[i] = original_volume // np.prod([x for x in new_shape if x != -1])
+            # Remove batch dimension and see if volumes match
+            if np.prod(shape[1:]) != np.prod(new_shape[1:]):
+                print("reshape: can't modify batch dimension.")
+                return False
         return True
 
     @reg.register("nn.pad", "target.tensorrt")
@@ -385,7 +409,7 @@ def register_tensorrt_annotations(trt_version):
         if attrs.exclude:
             print("{}: exclude not supported.".format(op_name))
             return False
-        if trt_version < (6, 0, 1) and any([x == 0 for x in map(int, attrs.axis)]):
+        if use_implicit_batch and any([x == 0 for x in map(int, attrs.axis)]):
             print("{}: can't modify batch dimension.".format(op_name))
             return False
         return True
@@ -419,7 +443,7 @@ def register_tensorrt_annotations(trt_version):
         if args[0].checked_type.dtype != "float32":
             print("strided_slice: only fp32 inputs are supported.")
             return False
-        if trt_version < (6, 0, 1):
+        if use_implicit_batch:
             batch_dim_begin_modified = attrs.begin[0] is not None and int(attrs.begin[0]) != 0
             batch_dim_end_modified = attrs.end[0] is not None and int(attrs.end[0]) != -1 and \
                                      int(attrs.end[0]) != int(args[0].checked_type.shape[0])
@@ -519,28 +543,64 @@ class SubgraphRemover(ExprMutator):
                 return subgraph_gv(*args)
         return super().visit_call(call)
 
-def PruneSubgraphs(mod, compiler="tensorrt"):
+def PruneSubgraphs(mod, compiler="tensorrt", use_implicit_batch=True, prune_no_macs=False):
     """
     Removes subgraphs which were originally partitioned for TRT if the number of
     multiply-accumulates is 0. This is a heuristic which can improve performance by around 5%
     because TVM provides better optimization for certain ops.
     """
-    subgraph_with_macs = []
+    subgraphs_to_remove = []
+
+    def is_valid_subgraph(func):
+        if not use_implicit_batch:
+            return True
+        input_batch_sizes = []
+        for var in func.params:
+            # In implicit batch mode, all inputs must have same batch size
+            if isinstance(var.checked_type, relay.TupleType):
+                for tupe_type in var.checked_type.fields:
+                    # Scalar inputs not allowed
+                    if len(tupe_type.shape) == 0:
+                        return False
+                    input_batch_sizes.append(int(tupe_type.shape[0]))
+            else:
+                # Scalar inputs not allowed
+                if len(var.checked_type.shape) == 0:
+                    return False
+                input_batch_sizes.append(int(var.checked_type.shape[0]))
+        if len(input_batch_sizes) > 1 and any([x != input_batch_sizes[0] for x in input_batch_sizes[1:]]):
+            return False
+        return True
+
+    # Remove invalid subgraphs
     for subgraph in mod.get_global_vars():
-        name = subgraph.name_hint
-        if not mod[name].attrs or mod[name].attrs["Compiler"] != compiler:
-            continue
-        num_macs = relay.analysis.get_total_mac_number(mod[name])
-        subgraph_with_macs.append([name, num_macs])
-    print("Subgraphs with computed # of MACS:", subgraph_with_macs)
-    subgraphs_to_remove = [name for name, num_macs in subgraph_with_macs if num_macs == 0]
+        for subgraph in mod.get_global_vars():
+            name = subgraph.name_hint
+            if not mod[name].attrs or mod[name].attrs["Compiler"] != compiler:
+                continue
+            if not is_valid_subgraph(mod[name]):
+                subgraphs_to_remove.append(name)
+
+    # Remove subgraphs with no multiply-accumulates
+    if prune_no_macs:
+        subgraph_with_macs = []
+        for subgraph in mod.get_global_vars():
+            name = subgraph.name_hint
+            if not mod[name].attrs or mod[name].attrs["Compiler"] != compiler:
+                continue
+            num_macs = relay.analysis.get_total_mac_number(mod[name])
+            subgraph_with_macs.append([name, num_macs])
+        print("Subgraphs with computed # of MACS:", subgraph_with_macs)
+        subgraphs_to_remove.extend([name for name, num_macs in subgraph_with_macs if num_macs == 0])
+    if len(subgraphs_to_remove) == 0:
+        return mod
     print("Will remove these subgraphs:", subgraphs_to_remove)
     # Create new pruned module
     new_mod = tvm.IRModule()
     new_mod["main"] = SubgraphRemover(subgraphs_to_remove, mod, new_mod).visit(mod["main"])
     return new_mod
 
-def EnableTrt(mod, params=None, trt_version=None, prune_subgraphs=False):
+def EnableTrt(mod, params=None, trt_version=None, use_implicit_batch=True, prune_subgraphs=False):
     """Converts the "main" function in the module into one that can be executed using
     TensorRT. If any of the operators are not supported by the TensorRT
     conversion, the unmodified program will be returned instead.
@@ -558,6 +618,11 @@ def EnableTrt(mod, params=None, trt_version=None, prune_subgraphs=False):
         Which version of TensorRT to target for partitioning as a tuple of
         (major, minor, patch). If not specified, will attempt to get using
         GetTrtVersion.
+
+    use_implicit_batch : bool
+        If false, will use explicit batch mode. Explicit batch mode is
+        available in TRT 6+. It increases operator coverage but comes at a
+        performance penalty.
 
     prune_subgraphs : bool
         If true, will prune subgraphs with 0 MACS and run them with TVM instead.
@@ -577,7 +642,7 @@ def EnableTrt(mod, params=None, trt_version=None, prune_subgraphs=False):
     assert isinstance(trt_version, (list, tuple))
     assert len(trt_version) == 3
 
-    register_tensorrt_annotations(trt_version)
+    register_tensorrt_annotations(trt_version, use_implicit_batch=use_implicit_batch)
 
     if params:
         # Bind params so that we can use FoldConstant.
@@ -597,6 +662,5 @@ def EnableTrt(mod, params=None, trt_version=None, prune_subgraphs=False):
                                     transform.InferType()])
     with tvm.transform.PassContext(opt_level=3):
         mod = seq(mod)
-    if prune_subgraphs:
-        mod = PruneSubgraphs(mod)
+    mod = PruneSubgraphs(mod, use_implicit_batch=use_implicit_batch, prune_no_macs=prune_subgraphs)
     return mod

--- a/python/tvm/relay/tensorrt.py
+++ b/python/tvm/relay/tensorrt.py
@@ -601,7 +601,8 @@ def PruneSubgraphs(mod, compiler="tensorrt", use_implicit_batch=True, prune_no_m
     new_mod["main"] = SubgraphRemover(subgraphs_to_remove, mod, new_mod).visit(mod["main"])
     return new_mod
 
-def EnableTrt(mod, params=None, trt_version=None, use_implicit_batch=True, max_workspace_size=1 << 30, prune_subgraphs=False):
+def EnableTrt(mod, params=None, trt_version=None, use_implicit_batch=True,
+              max_workspace_size=1 << 30, prune_subgraphs=False):
     """Converts the "main" function in the module into one that can be executed using
     TensorRT. If any of the operators are not supported by the TensorRT
     conversion, the unmodified program will be returned instead.

--- a/python/tvm/relay/tensorrt.py
+++ b/python/tvm/relay/tensorrt.py
@@ -18,6 +18,8 @@
 """
 Relay TensorRT codegen.
 """
+import numpy as np
+import os
 import tvm
 import tvm.relay.transform as transform
 from tvm import relay
@@ -26,8 +28,6 @@ from tvm.relay.build_module import bind_params_by_name
 from tvm.relay import op as reg
 from tvm.relay.transform import _ffi_api
 from tvm.relay.expr_functor import ExprMutator
-import numpy as np
-import os
 
 
 class LegalizeLayoutTranform(ExprMutator):

--- a/python/tvm/relay/tensorrt.py
+++ b/python/tvm/relay/tensorrt.py
@@ -18,8 +18,8 @@
 """
 Relay TensorRT codegen.
 """
-import numpy as np
 import os
+import numpy as np
 import tvm
 import tvm.relay.transform as transform
 from tvm import relay

--- a/python/tvm/relay/tensorrt.py
+++ b/python/tvm/relay/tensorrt.py
@@ -376,12 +376,12 @@ def register_tensorrt_annotations(trt_version, use_implicit_batch=True):
             # TRT cannot modify batch dimension.
             original_volume = np.prod(shape)
             # First, resolve 0.
-            for i in range(len(new_shape)):
-                if new_shape[i] == 0:
+            for i, value in enumerate(new_shape):
+                if value == 0:
                     new_shape[i] = shape[i]
             # Resolve -1.
-            for i in range(len(new_shape)):
-                if new_shape[i] == -1:
+            for i, value in enumerate(new_shape):
+                if value == -1:
                     new_shape[i] = original_volume // np.prod([x for x in new_shape if x != -1])
             # Remove batch dimension and see if volumes match
             if np.prod(shape[1:]) != np.prod(new_shape[1:]):
@@ -568,18 +568,18 @@ def PruneSubgraphs(mod, compiler="tensorrt", use_implicit_batch=True, prune_no_m
                 if len(var.checked_type.shape) == 0:
                     return False
                 input_batch_sizes.append(int(var.checked_type.shape[0]))
-        if len(input_batch_sizes) > 1 and any([x != input_batch_sizes[0] for x in input_batch_sizes[1:]]):
+        if len(input_batch_sizes) > 1 and \
+           any([x != input_batch_sizes[0] for x in input_batch_sizes[1:]]):
             return False
         return True
 
     # Remove invalid subgraphs
     for subgraph in mod.get_global_vars():
-        for subgraph in mod.get_global_vars():
-            name = subgraph.name_hint
-            if not mod[name].attrs or mod[name].attrs["Compiler"] != compiler:
-                continue
-            if not is_valid_subgraph(mod[name]):
-                subgraphs_to_remove.append(name)
+        name = subgraph.name_hint
+        if not mod[name].attrs or mod[name].attrs["Compiler"] != compiler:
+            continue
+        if not is_valid_subgraph(mod[name]):
+            subgraphs_to_remove.append(name)
 
     # Remove subgraphs with no multiply-accumulates
     if prune_no_macs:

--- a/python/tvm/relay/tensorrt.py
+++ b/python/tvm/relay/tensorrt.py
@@ -138,7 +138,7 @@ def register_tensorrt_annotations(trt_version, use_implicit_batch=True):
         # Can't register annotations more than once.
         return
     register_tensorrt_annotations.registered = True
-    if not use_implicit_batch and trt_version >= (6, 0, 1):
+    if not use_implicit_batch and trt_version < (6, 0, 1):
         print("Explicit batch mode only available for TRT 6+")
         use_implicit_batch = True
     # Ops which are always supported
@@ -385,7 +385,7 @@ def register_tensorrt_annotations(trt_version, use_implicit_batch=True):
                 if value == -1:
                     new_shape[i] = original_volume // np.prod([x for x in new_shape if x != -1])
             # Remove batch dimension and see if volumes match
-            if np.prod(shape[1:]) != np.prod(new_shape[1:]):
+            if shape[0] != new_shape[0]:
                 print("reshape: can't modify batch dimension.")
                 return False
         return True

--- a/src/runtime/contrib/tensorrt/tensorrt_builder.cc
+++ b/src/runtime/contrib/tensorrt/tensorrt_builder.cc
@@ -112,10 +112,12 @@ TensorRTBuilder::TensorRTBuilder(runtime::TensorRTLogger* logger,
   builder_ = nvinfer1::createInferBuilder(*logger);
 #if TRT_VERSION_GE(6, 0, 1)
   // Use INetworkV2.
-  auto flags = 0U;
-  if (!use_implicit_batch_) {
-    flags = 1U << static_cast<uint32_t>(
-        nvinfer1::NetworkDefinitionCreationFlag::kEXPLICIT_BATCH);
+  auto flags = 1U << static_cast<uint32_t>(
+      nvinfer1::NetworkDefinitionCreationFlag::kEXPLICIT_BATCH);;
+  if (use_implicit_batch_) {
+    flags = 0U;
+    batch_size_ = args[0]->shape[0];
+    builder_->setMaxBatchSize(batch_size_);
   }
   network_ = builder_->createNetworkV2(flags);
 #else

--- a/src/runtime/contrib/tensorrt/tensorrt_builder.cc
+++ b/src/runtime/contrib/tensorrt/tensorrt_builder.cc
@@ -105,11 +105,20 @@ GetOpConverters() {
 }
 
 TensorRTBuilder::TensorRTBuilder(runtime::TensorRTLogger* logger,
-    const std::vector<DLTensor*>& args, size_t max_workspace_size)
-    : execution_args_(args), max_workspace_size_(max_workspace_size) {
+    const std::vector<DLTensor*>& args, size_t max_workspace_size, bool use_implicit_batch)
+    : execution_args_(args), max_workspace_size_(max_workspace_size),
+      use_implicit_batch_(use_implicit_batch) {
   // Create TRT builder and network.
   builder_ = nvinfer1::createInferBuilder(*logger);
-#if TRT_HAS_IMPLICIT_BATCH
+#if TRT_VERSION_GE(6, 0, 1)
+  // Use INetworkV2.
+  auto flags = 0U;
+  if (!use_implicit_batch_) {
+    flags = 1U << static_cast<uint32_t>(
+        nvinfer1::NetworkDefinitionCreationFlag::kEXPLICIT_BATCH);
+  }
+  network_ = builder_->createNetworkV2(flags);
+#else
   // Use INetwork with implicit batch.
   batch_size_ = args[0]->shape[0];
   builder_->setMaxBatchSize(batch_size_);
@@ -117,12 +126,6 @@ TensorRTBuilder::TensorRTBuilder(runtime::TensorRTLogger* logger,
   const bool use_fp16 = dmlc::GetEnv("TVM_TENSORRT_USE_FP16", false);
   builder_->setFp16Mode(use_fp16);
   network_ = builder_->createNetwork();
-#else
-  // Use INetworkV2 with explicit batch.
-  const auto flags =
-      1U << static_cast<uint32_t>(
-          nvinfer1::NetworkDefinitionCreationFlag::kEXPLICIT_BATCH);
-  network_ = builder_->createNetworkV2(flags);
 #endif
 }
 
@@ -170,26 +173,28 @@ runtime::TrtEngineAndContext TensorRTBuilder::BuildEngine(
   VisitExpr(func->body);
   ProcessOutputs(func->body);
 // Build engine.
-#if TRT_HAS_IMPLICIT_BATCH
-  nvinfer1::ICudaEngine* engine = builder_->buildCudaEngine(*network_);
-#else
+#if TRT_VERSION_GE(6, 0, 1)
   config_ = builder_->createBuilderConfig();
   config_->setMaxWorkspaceSize(max_workspace_size_);
   if (dmlc::GetEnv("TVM_TENSORRT_USE_FP16", false)) {
     config_->setFlag(nvinfer1::BuilderFlag::kFP16);
   }
   // Add profiles.
-  auto profile = builder_->createOptimizationProfile();
-  for (int i = 0; i < network_->getNbInputs(); ++i) {
-    auto name = network_->getInput(i)->getName();
-    auto dims = network_->getInput(i)->getDimensions();
-    profile->setDimensions(name, nvinfer1::OptProfileSelector::kMIN, dims);
-    profile->setDimensions(name, nvinfer1::OptProfileSelector::kOPT, dims);
-    profile->setDimensions(name, nvinfer1::OptProfileSelector::kMAX, dims);
+  if (!use_implicit_batch_) {
+    auto profile = builder_->createOptimizationProfile();
+    for (int i = 0; i < network_->getNbInputs(); ++i) {
+      auto name = network_->getInput(i)->getName();
+      auto dims = network_->getInput(i)->getDimensions();
+      profile->setDimensions(name, nvinfer1::OptProfileSelector::kMIN, dims);
+      profile->setDimensions(name, nvinfer1::OptProfileSelector::kOPT, dims);
+      profile->setDimensions(name, nvinfer1::OptProfileSelector::kMAX, dims);
+    }
+    config_->addOptimizationProfile(profile);
   }
-  config_->addOptimizationProfile(profile);
   nvinfer1::ICudaEngine* engine =
       builder_->buildEngineWithConfig(*network_, *config_);
+#else
+  nvinfer1::ICudaEngine* engine = builder_->buildCudaEngine(*network_);
 #endif
   CleanUp();
   const int num_input_bindings = std::count(
@@ -313,7 +318,7 @@ void TensorRTBuilder::VisitExpr_(const TupleNode* op) {
 nvinfer1::ITensor* TensorRTBuilder::AddInput(const std::string& tensor_name, const Type& type) {
   auto shape = GetShape(type);
   // Remove batch dim when not in explicit batch mode.
-  if (TRT_HAS_IMPLICIT_BATCH && shape.size() > 1) {
+  if (use_implicit_batch_ && shape.size() > 1) {
     shape.erase(shape.begin());
   }
   DLOG(INFO) << "Added TRT network input: " << tensor_name << " "
@@ -373,7 +378,7 @@ void TensorRTBuilder::VisitExpr_(const ConstantNode* node) {
   nvinfer1::Weights weight = GetNdArrayAsWeights(node->data, kDLCPU);
   auto shape = node->data.Shape();
   // Remove batch dim when not in explicit batch mode.
-  if (TRT_HAS_IMPLICIT_BATCH && shape.size() > 1 && shape[0] == 1) {
+  if (use_implicit_batch_ && shape.size() > 1 && shape[0] == 1) {
     shape.erase(shape.begin());
   }
   nvinfer1::Dims dims = VectorToTrtDims(shape);
@@ -444,7 +449,7 @@ void TensorRTBuilder::VisitExpr_(const CallNode* call) {
 
 void TensorRTBuilder::CleanUp() {
   network_->destroy();
-#if !TRT_HAS_IMPLICIT_BATCH
+#if TRT_VERSION_GE(6, 0, 1)
   config_->destroy();
 #endif
   builder_->destroy();

--- a/src/runtime/contrib/tensorrt/tensorrt_builder.h
+++ b/src/runtime/contrib/tensorrt/tensorrt_builder.h
@@ -40,6 +40,10 @@
   (NV_TENSORRT_MAJOR == major && NV_TENSORRT_MINOR == minor && \
   NV_TENSORRT_PATCH >= patch))
 
+// Explicit batch mode increases operator coverage but reduces performance. Disable for now.
+#define TRT_HAS_IMPLICIT_BATCH true
+// #define TRT_HAS_IMPLICIT_BATCH (!TRT_VERSION_GE(6, 0, 1))
+
 #include "tensorrt_logger.h"
 
 namespace tvm {
@@ -168,7 +172,7 @@ class TensorRTBuilder : public ExprVisitor {
   /*! \brief TensorRT builder. */
   nvinfer1::IBuilder* builder_;
 
-#if TRT_VERSION_GE(6, 0, 1)
+#if !TRT_HAS_IMPLICIT_BATCH
   /*! \brief TensorRT builder config. */
   nvinfer1::IBuilderConfig* config_;
 #endif

--- a/src/runtime/contrib/tensorrt/tensorrt_module.cc
+++ b/src/runtime/contrib/tensorrt/tensorrt_module.cc
@@ -83,7 +83,8 @@ class TensorRTModule : public runtime::ModuleNode {
         auto inputs = ConvertInputs(args);
         std::string key = GetSubgraphKey(serialized_subgraphs_[name]);
         this->serialized_subgraphs_[name].clear();
-        relay::contrib::TensorRTBuilder builder(&logger_, inputs, max_workspace_size_, use_implicit_batch_);
+        relay::contrib::TensorRTBuilder builder(&logger_, inputs, max_workspace_size_,
+                                                use_implicit_batch_);
         auto engine_and_context = builder.BuildEngine(func);
         CacheEngineToDisk(key, engine_and_context);
         LOG(INFO) << "Finished building TensorRT engine for subgraph " << name;

--- a/src/runtime/contrib/tensorrt/tensorrt_module.cc
+++ b/src/runtime/contrib/tensorrt/tensorrt_module.cc
@@ -48,6 +48,7 @@ class TensorRTModule : public runtime::ModuleNode {
       const std::unordered_map<std::string, std::string>& serialized_subgraphs)
       : serialized_subgraphs_(serialized_subgraphs) {
     max_workspace_size_ = dmlc::GetEnv("TVM_TENSORRT_MAX_WORKSPACE_SIZE", size_t(1) << 31);
+    use_implicit_batch_ = dmlc::GetEnv("TVM_TENSORRT_USE_IMPLICIT_BATCH", true);
 #if TVM_GRAPH_RUNTIME_TENSORRT
     GetCachedEnginesFromDisk();
 #endif
@@ -82,7 +83,7 @@ class TensorRTModule : public runtime::ModuleNode {
         auto inputs = ConvertInputs(args);
         std::string key = GetSubgraphKey(serialized_subgraphs_[name]);
         this->serialized_subgraphs_[name].clear();
-        relay::contrib::TensorRTBuilder builder(&logger_, inputs, max_workspace_size_);
+        relay::contrib::TensorRTBuilder builder(&logger_, inputs, max_workspace_size_, use_implicit_batch_);
         auto engine_and_context = builder.BuildEngine(func);
         CacheEngineToDisk(key, engine_and_context);
         LOG(INFO) << "Finished building TensorRT engine for subgraph " << name;
@@ -135,6 +136,9 @@ class TensorRTModule : public runtime::ModuleNode {
 
   /*! \brief Max workspace size for TensorRT */
   size_t max_workspace_size_;
+
+  /*! \brief Whether to use implicit batch mode. */
+  bool use_implicit_batch_;
 
 #if TVM_GRAPH_RUNTIME_TENSORRT
   /*! \brief Map of function name to TRT engine if built already. */
@@ -193,15 +197,17 @@ class TensorRTModule : public runtime::ModuleNode {
         LOG(FATAL) << "Only float32 inputs are supported.";
       }
       bindings[binding_index] = reinterpret_cast<float*>(arg->data);
-#if !TRT_HAS_IMPLICIT_BATCH
+#if TRT_VERSION_GE(6, 0, 1)
       // Set binding dimensions for INetworkV2 explicit batch mode engines.
-      nvinfer1::Dims dims;
-      dims.d[0] = 1;
-      dims.nbDims = arg->ndim;
-      for (int i = 0; i < arg->ndim; ++i) {
-        dims.d[i] = arg->shape[i];
+      if (!use_implicit_batch_) {
+        nvinfer1::Dims dims;
+        dims.d[0] = 1;
+        dims.nbDims = arg->ndim;
+        for (int i = 0; i < arg->ndim; ++i) {
+          dims.d[i] = arg->shape[i];
+        }
+        context->setBindingDimensions(binding_index, dims);
       }
-      context->setBindingDimensions(binding_index, dims);
 #endif
     }
     // Set outputs.
@@ -213,13 +219,18 @@ class TensorRTModule : public runtime::ModuleNode {
       CHECK_NE(binding_index, -1);
       bindings[binding_index] = reinterpret_cast<float*>(out_arg->data);
     }
-#if !TRT_HAS_IMPLICIT_BATCH
-    CHECK(context->executeV2(bindings.data())) << "Running TensorRT failed.";
+#if TRT_VERSION_GE(6, 0, 1)
+    if (use_implicit_batch_) {
+      // Use batch size from first input.
+      const int batch_size = inputs[0]->shape[0];
+      CHECK(context->execute(batch_size, bindings.data())) << "Running TensorRT failed.";
+    } else {
+      CHECK(context->executeV2(bindings.data())) << "Running TensorRT failed.";
+    }
 #else
     // Use batch size from first input.
     const int batch_size = inputs[0]->shape[0];
-    CHECK(context->execute(batch_size, bindings.data()))
-        << "Running TensorRT failed.";
+    CHECK(context->execute(batch_size, bindings.data())) << "Running TensorRT failed.";
 #endif
     *rv = bindings[num_bindings - num_outputs];
   }
@@ -307,6 +318,7 @@ class TensorRTModule : public runtime::ModuleNode {
     writer.BeginObject();
     writer.WriteObjectKeyValue("subgraphs", serialized_subgraphs_);
     writer.WriteObjectKeyValue("max_workspace_size", max_workspace_size_);
+    writer.WriteObjectKeyValue("use_implicit_batch", use_implicit_batch_);
     writer.EndObject();
     return os.str();
   }
@@ -315,17 +327,20 @@ class TensorRTModule : public runtime::ModuleNode {
   static Module CreateModuleFromString(const std::string& str) {
     std::unordered_map<std::string, std::string> serialized_subgraphs;
     size_t max_workspace_size = 0;
+    bool use_implicit_batch = true;
     std::istringstream is(str);
     dmlc::JSONReader reader(&is);
     dmlc::JSONObjectReadHelper helper;
     helper.DeclareField("subgraphs", &serialized_subgraphs);
     helper.DeclareOptionalField("max_workspace_size", &max_workspace_size);
+    helper.DeclareOptionalField("use_implicit_batch", &use_implicit_batch);
     helper.ReadAllFields(&reader);
     auto n = make_object<TensorRTModule>(serialized_subgraphs);
     // Use max_workspace_size from artifact if it is set and it is not overriden by env var.
     if (max_workspace_size != 0 && dmlc::GetEnv("TVM_TENSORRT_MAX_WORKSPACE_SIZE", 0) != 0) {
       n->max_workspace_size_ = max_workspace_size;
     }
+    n->use_implicit_batch_ = use_implicit_batch;
     return Module(n);
   }
 };

--- a/src/runtime/contrib/tensorrt/tensorrt_module.cc
+++ b/src/runtime/contrib/tensorrt/tensorrt_module.cc
@@ -193,7 +193,7 @@ class TensorRTModule : public runtime::ModuleNode {
         LOG(FATAL) << "Only float32 inputs are supported.";
       }
       bindings[binding_index] = reinterpret_cast<float*>(arg->data);
-#if TRT_VERSION_GE(6, 0, 1)
+#if !TRT_HAS_IMPLICIT_BATCH
       // Set binding dimensions for INetworkV2 explicit batch mode engines.
       nvinfer1::Dims dims;
       dims.d[0] = 1;
@@ -213,7 +213,7 @@ class TensorRTModule : public runtime::ModuleNode {
       CHECK_NE(binding_index, -1);
       bindings[binding_index] = reinterpret_cast<float*>(out_arg->data);
     }
-#if TRT_VERSION_GE(6, 0, 1)
+#if !TRT_HAS_IMPLICIT_BATCH
     CHECK(context->executeV2(bindings.data())) << "Running TensorRT failed.";
 #else
     // Use batch size from first input.

--- a/src/runtime/contrib/tensorrt/tensorrt_ops.h
+++ b/src/runtime/contrib/tensorrt/tensorrt_ops.h
@@ -490,8 +490,8 @@ class BatchNormOpConverter : public TrtOpConverter {
     }
     params->outputs.push_back(output);
     // Create dummy outputs for new running mean and new running variance.
-    params->outputs.push_back(CreateScalar(params, 0.0f, nvinfer1::Dims{1, gamma.count}));
-    params->outputs.push_back(CreateScalar(params, 0.0f, nvinfer1::Dims{1, gamma.count}));
+    // params->outputs.push_back(CreateScalar(params, 0.0f, nvinfer1::Dims{1, gamma.count}));
+    // params->outputs.push_back(CreateScalar(params, 0.0f, nvinfer1::Dims{1, gamma.count}));
   }
 };
 

--- a/src/runtime/contrib/tensorrt/tensorrt_ops.h
+++ b/src/runtime/contrib/tensorrt/tensorrt_ops.h
@@ -39,7 +39,6 @@
 // #include "NvInferPlugin.h"
 #include "utils.h"
 
-#define TRT_HAS_IMPLICIT_BATCH (!TRT_VERSION_GE(6, 0, 1))
 
 namespace tvm {
 namespace relay {

--- a/src/runtime/contrib/tensorrt/tensorrt_ops.h
+++ b/src/runtime/contrib/tensorrt/tensorrt_ops.h
@@ -39,6 +39,11 @@
 // #include "NvInferPlugin.h"
 #include "utils.h"
 
+#if TRT_VERSION_GE(6, 0, 1)
+#define TRT_HAS_IMPLICIT_BATCH(params) (params->network->hasImplicitBatchDimension())
+#else
+#define TRT_HAS_IMPLICIT_BATCH(params) (true)
+#endif
 
 namespace tvm {
 namespace relay {
@@ -138,7 +143,7 @@ class TrtOpConverter {
     auto layer = params->network->addShuffle(*input);
     CHECK(layer != nullptr);
     nvinfer1::Permutation perm;
-    if (TRT_HAS_IMPLICIT_BATCH) {
+    if (TRT_HAS_IMPLICIT_BATCH(params)) {
       // Batch dimension cannot be modified.
       CHECK_EQ(input->getDimensions().nbDims, order.size() - 1);
       CHECK_EQ(order[0], 0);
@@ -163,12 +168,12 @@ class TrtOpConverter {
    */
   int ConvertAxis(AddTrtLayerParams* params, int axis, int input_rank) const {
     // Add 1 for missing batch dim.
-    if (TRT_HAS_IMPLICIT_BATCH) {
+    if (TRT_HAS_IMPLICIT_BATCH(params)) {
       input_rank += 1;
     }
     CHECK(axis >= -input_rank && axis < input_rank);
     if (axis < 0) axis += input_rank;
-    if (TRT_HAS_IMPLICIT_BATCH) {
+    if (TRT_HAS_IMPLICIT_BATCH(params)) {
       // Can't modify batch dimenson.
       CHECK_NE(axis, 0);
       // Subtract 1 for implicit batch dim.
@@ -400,7 +405,7 @@ class DenseOpConverter : public TrtOpConverter {
     auto input_tensor = params->inputs.at(0).tensor;
     auto input_dims = TrtDimsToVector(input_tensor->getDimensions());
     CHECK(input_dims.size() > 0 && input_dims.size() <= 3);
-    const int required_rank = TRT_HAS_IMPLICIT_BATCH ? 3 : 4;
+    const int required_rank = TRT_HAS_IMPLICIT_BATCH(params) ? 3 : 4;
     const bool need_reshape_on_input = input_dims.size() != required_rank;
     if (need_reshape_on_input) {
       // Add dims of size 1 until rank is required_rank.
@@ -496,7 +501,7 @@ class BatchFlattenOpConverter : public TrtOpConverter {
 
   void Convert(AddTrtLayerParams* params) const {
     std::vector<int> new_shape{-1};
-    if (!TRT_HAS_IMPLICIT_BATCH) {
+    if (!TRT_HAS_IMPLICIT_BATCH(params)) {
       new_shape.insert(new_shape.begin(),
                        params->inputs.at(0).tensor->getDimensions().d[0]);
     }
@@ -633,8 +638,8 @@ class GlobalPoolingOpConverter : public TrtOpConverter {
                               << " in TensorRT";
     const auto* pool_attr = params->call->attrs.as<GlobalPool2DAttrs>();
     CHECK_EQ(pool_attr->layout, "NCHW");
-    const int h = TRT_HAS_IMPLICIT_BATCH ? input_dims[1] : input_dims[2];
-    const int w = TRT_HAS_IMPLICIT_BATCH ? input_dims[2] : input_dims[3];
+    const int h = TRT_HAS_IMPLICIT_BATCH(params) ? input_dims[1] : input_dims[2];
+    const int w = TRT_HAS_IMPLICIT_BATCH(params) ? input_dims[2] : input_dims[3];
     auto pool_layer = params->network->addPooling(*input_tensor, it->second,
                                                   nvinfer1::DimsHW(h, w));
     CHECK(pool_layer != nullptr);
@@ -746,7 +751,7 @@ class BiasAddOpConverter : public TrtOpConverter {
   void Convert(AddTrtLayerParams* params) const {
     auto input_tensor = params->inputs.at(0).tensor;
     auto input_dims = TrtDimsToVector(input_tensor->getDimensions());
-    const int required_rank = TRT_HAS_IMPLICIT_BATCH ? 3 : 4;
+    const int required_rank = TRT_HAS_IMPLICIT_BATCH(params) ? 3 : 4;
     CHECK(input_dims.size() > 0 && input_dims.size() <= required_rank);
     const bool need_reshape_on_input = input_dims.size() != required_rank;
     if (need_reshape_on_input) {
@@ -849,7 +854,7 @@ class ReshapeOpConverter : public TrtOpConverter {
     CHECK_EQ(attrs->reverse, false);
     std::vector<int> new_shape;
     const int start_index =
-        TRT_HAS_IMPLICIT_BATCH ? 1 : 0;
+        TRT_HAS_IMPLICIT_BATCH(params) ? 1 : 0;
     for (size_t i = start_index; i < attrs->newshape.size(); ++i) {
       const int value = attrs->newshape[i].as<IntImmNode>()->value;
       CHECK_GE(value, -1);
@@ -867,9 +872,9 @@ class PadOpConverter : public TrtOpConverter {
     auto input = params->inputs.at(0).tensor;
     const auto* attrs = params->call->attrs.as<PadAttrs>();
     const int input_rank_with_batch =
-        input->getDimensions().nbDims + (TRT_HAS_IMPLICIT_BATCH ? 1 : 0);
+        input->getDimensions().nbDims + (TRT_HAS_IMPLICIT_BATCH(params) ? 1 : 0);
     CHECK_EQ(input_rank_with_batch, attrs->pad_width.size());
-    CHECK(!TRT_HAS_IMPLICIT_BATCH ||
+    CHECK(!TRT_HAS_IMPLICIT_BATCH(params) ||
           (attrs->pad_width[0][0].as<IntImmNode>()->value == 0 &&
            attrs->pad_width[0][1].as<IntImmNode>()->value == 0))
         << "Cannot pad on batch dimension.";
@@ -949,12 +954,12 @@ class StridedSliceOpConverter : public TrtOpConverter {
     auto input_dims = TrtDimsToVector(input->getDimensions());
     const auto* attrs = params->call->attrs.as<StridedSliceAttrs>();
     const int input_rank_with_batch =
-        input->getDimensions().nbDims + (TRT_HAS_IMPLICIT_BATCH ? 1 : 0);
+        input->getDimensions().nbDims + (TRT_HAS_IMPLICIT_BATCH(params) ? 1 : 0);
     CHECK_EQ(input_rank_with_batch, attrs->begin.size());
     CHECK_EQ(input_rank_with_batch, attrs->end.size());
     const bool default_strides =
         !attrs->strides.defined() || attrs->strides.size() == 0;
-    if (TRT_HAS_IMPLICIT_BATCH) {
+    if (TRT_HAS_IMPLICIT_BATCH(params)) {
       CHECK(default_strides || !attrs->strides[0].defined() ||
             attrs->strides[0].as<IntImmNode>()->value == 1);
     }
@@ -966,7 +971,7 @@ class StridedSliceOpConverter : public TrtOpConverter {
       return value;
     };
 
-    const int start_index = TRT_HAS_IMPLICIT_BATCH ? 1 : 0;
+    const int start_index = TRT_HAS_IMPLICIT_BATCH(params) ? 1 : 0;
     std::vector<int> start, size, strides;
     for (size_t i = start_index; i < attrs->begin.size(); ++i) {
       const int begin_value =
@@ -1016,8 +1021,8 @@ class AdaptivePoolingOpConverter : public TrtOpConverter {
     // mathematically exact except when output_size is (1, 1).
     // Annotation rules will only allow output size of (1, 1).
     auto output_size = nvinfer1::DimsHW(1, 1);
-    const int h = TRT_HAS_IMPLICIT_BATCH ? input_dims[1] : input_dims[2];
-    const int w = TRT_HAS_IMPLICIT_BATCH ? input_dims[2] : input_dims[3];
+    const int h = TRT_HAS_IMPLICIT_BATCH(params) ? input_dims[1] : input_dims[2];
+    const int w = TRT_HAS_IMPLICIT_BATCH(params) ? input_dims[2] : input_dims[3];
     const auto stride =
         nvinfer1::DimsHW(h / output_size.h(), w / output_size.w());
     const auto window_size =
@@ -1046,12 +1051,12 @@ class ResizeOpConverter : public TrtOpConverter {
     CHECK(it != op_map.end()) << "Unsupported resize type " << attrs->method;
     CHECK_EQ(attrs->size.size(), 2);
     auto output_dims = TrtDimsToVector(input->getDimensions());
-    const int required_rank = TRT_HAS_IMPLICIT_BATCH ? 3 : 4;
+    const int required_rank = TRT_HAS_IMPLICIT_BATCH(params) ? 3 : 4;
     CHECK_EQ(output_dims.size(), required_rank);
     CHECK(attrs->layout == "NCHW" || attrs->layout == "NHWC");
     int h_index = attrs->layout == "NCHW" ? 2 : 1;
     int w_index = attrs->layout == "NCHW" ? 3 : 2;
-    if (TRT_HAS_IMPLICIT_BATCH) {
+    if (TRT_HAS_IMPLICIT_BATCH(params)) {
       h_index -= 1;
       w_index -= 1;
     }
@@ -1150,12 +1155,12 @@ class UpsamplingOpConverter : public TrtOpConverter {
     auto it = op_map.find(attrs->method);
     CHECK(it != op_map.end()) << "Unsupported resize type " << attrs->method;
     auto output_dims = TrtDimsToVector(input->getDimensions());
-    const int required_rank = TRT_HAS_IMPLICIT_BATCH ? 3 : 4;
+    const int required_rank = TRT_HAS_IMPLICIT_BATCH(params) ? 3 : 4;
     CHECK_EQ(output_dims.size(), required_rank);
     CHECK(attrs->layout == "NCHW" || attrs->layout == "NHWC");
     int h_index = attrs->layout == "NCHW" ? 2 : 1;
     int w_index = attrs->layout == "NCHW" ? 3 : 2;
-    if (TRT_HAS_IMPLICIT_BATCH) {
+    if (TRT_HAS_IMPLICIT_BATCH(params)) {
       h_index -= 1;
       w_index -= 1;
     }

--- a/src/runtime/contrib/tensorrt/tensorrt_ops.h
+++ b/src/runtime/contrib/tensorrt/tensorrt_ops.h
@@ -489,9 +489,6 @@ class BatchNormOpConverter : public TrtOpConverter {
       output = Transpose(params, output, {0, 2, 3, 1});
     }
     params->outputs.push_back(output);
-    // Create dummy outputs for new running mean and new running variance.
-    // params->outputs.push_back(CreateScalar(params, 0.0f, nvinfer1::Dims{1, gamma.count}));
-    // params->outputs.push_back(CreateScalar(params, 0.0f, nvinfer1::Dims{1, gamma.count}));
   }
 };
 

--- a/tests/python/relay/test_tensorrt.py
+++ b/tests/python/relay/test_tensorrt.py
@@ -528,8 +528,8 @@ def test_tensorrt_serialize():
         mod.run(data=i_data)
 
 if __name__ == '__main__':
-    test_tensorrt_ops()
-    test_tensorrt_simple()
-    test_tensorrt_not_compatible()
+    # test_tensorrt_ops()
+    # test_tensorrt_simple()
+    # test_tensorrt_not_compatible()
     test_tensorrt_integration()
-    test_tensorrt_serialize()
+    # test_tensorrt_serialize()

--- a/tests/python/relay/test_tensorrt.py
+++ b/tests/python/relay/test_tensorrt.py
@@ -528,8 +528,8 @@ def test_tensorrt_serialize():
         mod.run(data=i_data)
 
 if __name__ == '__main__':
-    # test_tensorrt_ops()
-    # test_tensorrt_simple()
-    # test_tensorrt_not_compatible()
+    test_tensorrt_ops()
+    test_tensorrt_simple()
+    test_tensorrt_not_compatible()
     test_tensorrt_integration()
-    # test_tensorrt_serialize()
+    test_tensorrt_serialize()


### PR DESCRIPTION
TRT 6 introduced an explicit batch mode which greatly increased operator coverage in TRT. My previous PR to enable heterogenous TRT execution switched to always use explicit batch mode. However, we discovered this caused some performance regressions. Therefore, this PR will add a parameter to `EnableTRT()` to use implicit batch mode and adjusts the annotation to reflect that.