### PR TITLE
Temporarily disable test_forward_ssd_mobilenet_v1

### DIFF
--- a/tests/python/frontend/tflite/test_forward.py
+++ b/tests/python/frontend/tflite/test_forward.py
@@ -1775,25 +1775,6 @@ def test_forward_qnn_mobilenet_v3_net():
     tvm_sorted_labels = tvm_predictions.argsort()[-3:][::-1]
     tvm.testing.assert_allclose(tvm_sorted_labels, tflite_sorted_labels)
 
-#######################################################################
-# SSD Mobilenet
-# -------------
-
-def test_forward_ssd_mobilenet_v1():
-    """Test the SSD Mobilenet V1 TF Lite model."""
-    # SSD MobilenetV1
-    tflite_model_file = tf_testing.get_workload_official(
-        "https://raw.githubusercontent.com/dmlc/web-data/master/tensorflow/models/object_detection/ssd_mobilenet_v1_coco_2018_01_28_nopp.tgz",
-        "ssd_mobilenet_v1_coco_2018_01_28_nopp.tflite")
-    with open(tflite_model_file, "rb") as f:
-        tflite_model_buf = f.read()
-    np.random.seed(0)
-    data = np.random.uniform(size=(1, 300, 300, 3)).astype('float32')
-    tflite_output = run_tflite_graph(tflite_model_buf, data)
-    tvm_output = run_tvm_graph(tflite_model_buf, data, 'normalized_input_image_tensor', num_output=2)
-    for i in range(2):
-        tvm.testing.assert_allclose(np.squeeze(tvm_output[i]), np.squeeze(tflite_output[i]),
-                                    rtol=1e-5, atol=2e-5)
 
 #######################################################################
 # MediaPipe
@@ -1886,7 +1867,6 @@ if __name__ == '__main__':
     test_forward_mobilenet_v3()
     test_forward_inception_v3_net()
     test_forward_inception_v4_net()
-    test_forward_ssd_mobilenet_v1()
     test_forward_mediapipe_hand_landmark()
 
     # End to End quantized


### PR DESCRIPTION
This test is failing due to the file it tries to download no longer existing.

Upstream removed test
https://github.com/apache/incubator-tvm/pull/5477

Upstream added new test which replaces it
https://github.com/apache/incubator-tvm/pull/5479