### PR TITLE
Add GetOutputName to graph_runtime

### DIFF
--- a/src/runtime/graph/graph_runtime.cc
+++ b/src/runtime/graph/graph_runtime.cc
@@ -168,6 +168,18 @@ int GraphRuntime::NumOutputs() const {
   return outputs_.size();
 }
 /*!
+ * \brief Get the number of the index-th output.
+ * \param index The output index.
+ *
+ * \return The name of the index-th output.
+ */
+std::string GraphRuntime::GetOutputName(int index) const {
+  CHECK_LT(static_cast<size_t>(index), outputs_.size())
+      << "The index of ouf of range.";
+  const uint32_t nid = outputs_[index].node_id;
+  return nodes_[nid].name;
+}
+/*!
  * \brief Return NDArray for given input index.
  * \param index The input index.
  *

--- a/src/runtime/graph/graph_runtime.h
+++ b/src/runtime/graph/graph_runtime.h
@@ -148,6 +148,13 @@ class GraphRuntime : public ModuleNode {
    */
   int NumOutputs() const;
   /*!
+   * \brief Get the number of the index-th output.
+   * \param index The output index.
+   *
+   * \return The name of the index-th output.
+   */
+  std::string GetOutputName(int index) const;
+  /*!
    * \brief Get the names of weight inputs.
    *
    * \return The names fo the weight inputs.


### PR DESCRIPTION
neo-ai/tvm already has custom method to `GetInputName` by input index. This PR adds similar method for outputs - `GetOutputName` by output index.
Tested with DLR model_peeker - TVM Model Constructor prints GetOutputName(0) - `==== fused_nn_softmax ===`
```
$ bin/model_peeker ~/workplace/models/mobilenetv2_0.75_cpu
==== fused_nn_softmax ===
backend is tvm
num_inputs = 1
num_weights = 107
num_outputs = 1
input_names: data, 
output shapes: 
[1, 1000, ]
```
