### PR TITLE
Add GetOutputType to graph_runtime

### DIFF
--- a/src/runtime/graph/graph_runtime.cc
+++ b/src/runtime/graph/graph_runtime.cc
@@ -175,6 +175,17 @@ int GraphRuntime::NumOutputs() const {
   return outputs_.size();
 }
 /*!
+ * \brief Get the type of the index-th output.
+ * \param index The output index.
+ *
+ * \return The type of the index-th output.
+ */
+std::string GraphRuntime::GetOutputType(int index) const {
+  CHECK_LT(static_cast<size_t>(index), outputs_.size())
+      << "The index is out of range.";
+  return attrs_.dltype[outputs_[index].node_id];
+}
+/*!
  * \brief Return NDArray for given input index.
  * \param index The input index.
  *

--- a/src/runtime/graph/graph_runtime.h
+++ b/src/runtime/graph/graph_runtime.h
@@ -155,6 +155,13 @@ class TVM_DLL GraphRuntime : public ModuleNode {
    */
   int NumOutputs() const;
   /*!
+   * \brief Get the type of the index-th output.
+   * \param index The output index.
+   *
+   * \return The type of the index-th output.
+   */
+  std::string GetOutputType(int index) const;
+  /*!
    * \brief Get the names of weight inputs.
    *
    * \return The names fo the weight inputs.


### PR DESCRIPTION
`GetOutputType(int index)` will be used by DLR to get output type. 

`neo-ai/tvm` already has several custom methods in `graph-runtume`  to query input/outputs info, such as `GetInputType`, `GetInputName`, `NumInputs` and `NumOutputs`

`GetOutputType` was tested in DLR (using model-peeker)
```
for (int i = 0; i < num_outputs_; i++) {
  std::string out_type = tvm_graph_runtime_->GetOutputType(i);
  printf("=== output: %d, type: %s ===\n", i, out_type.c_str());
}
```
```
# bin/model_peeker ~/workplace/models/mobilenetv2_0.75_cpu
=== input: data, type: float32 ===
=== output: 0, type: float32 ===
backend is tvm
num_inputs = 1
num_weights = 107
num_outputs = 1
input_names: data, 
output shapes: 
[1, 1000, ]
```