### PR TITLE
Fix GetOutputType by using entry_id instead of node_id

### DIFF
--- a/src/runtime/graph/graph_runtime.cc
+++ b/src/runtime/graph/graph_runtime.cc
@@ -183,7 +183,8 @@ int GraphRuntime::NumOutputs() const {
 std::string GraphRuntime::GetOutputType(int index) const {
   CHECK_LT(static_cast<size_t>(index), outputs_.size())
       << "The index is out of range.";
-  return attrs_.dltype[outputs_[index].node_id];
+  uint32_t eid = this->entry_id(outputs_[index]);
+  return attrs_.dltype[eid];
 }
 /*!
  * \brief Return NDArray for given input index.

--- a/src/runtime/graph/graph_runtime.cc
+++ b/src/runtime/graph/graph_runtime.cc
@@ -131,7 +131,8 @@ std::string GraphRuntime::GetInputName(int index) const {
 std::string GraphRuntime::GetInputType(int index) const {
   CHECK_LT(static_cast<size_t>(index), input_nodes_.size())
       << "The index is out of range.";
-  return attrs_.dltype[input_nodes_[index]];
+  uint32_t eid = this->entry_id(input_nodes_[index], 0);
+  return attrs_.dltype[eid];
 }
 /*!
  * \brief Get the names of weight inputs.


### PR DESCRIPTION
Fixes issue with https://github.com/neo-ai/tvm/pull/107 where the node id was used instead of the entry id to retrieve output type.

Here is some debug output to prove this is the correct way to access output types. Output 1 was incorrectly returning "int32" instead of "float32".

```
[18:04:42] /data/neo-ai-dlr/3rdparty/tvm/src/runtime/graph/graph_runtime.cc:187: Output: 0 node_id: 21 entry_id: 26
[18:04:42] /data/neo-ai-dlr/3rdparty/tvm/src/runtime/graph/graph_runtime.cc:188: dltype[21]: float32
[18:04:42] /data/neo-ai-dlr/3rdparty/tvm/src/runtime/graph/graph_runtime.cc:189: dltype[26]: float32
[18:04:42] /data/neo-ai-dlr/3rdparty/tvm/src/runtime/graph/graph_runtime.cc:187: Output: 1 node_id: 22 entry_id: 27
[18:04:42] /data/neo-ai-dlr/3rdparty/tvm/src/runtime/graph/graph_runtime.cc:188: dltype[22]: int32
[18:04:42] /data/neo-ai-dlr/3rdparty/tvm/src/runtime/graph/graph_runtime.cc:189: dltype[27]: float32
[18:04:42] /data/neo-ai-dlr/3rdparty/tvm/src/runtime/graph/graph_runtime.cc:187: Output: 2 node_id: 23 entry_id: 28
[18:04:42] /data/neo-ai-dlr/3rdparty/tvm/src/runtime/graph/graph_runtime.cc:188: dltype[23]: float32
[18:04:42] /data/neo-ai-dlr/3rdparty/tvm/src/runtime/graph/graph_runtime.cc:189: dltype[28]: float32
```


Output was generated using the following debug log code:

```
std::string GraphRuntime::GetOutputType(int index) const {
  CHECK_LT(static_cast<size_t>(index), outputs_.size())
      << "The index is out of range.";
  uint32_t eid = this->entry_id(outputs_[index]);
  LOG(INFO) << "Output: " << index << " node_id: " << outputs_[index].node_id << " entry_id: " << eid;
  LOG(INFO) << "dltype[" << outputs_[index].node_id << "]: " << attrs_.dltype[outputs_[index].node_id];
  LOG(INFO) << "dltype[" << eid << "]: " << attrs_.dltype[eid];
  return attrs_.dltype[eid];
}
```