### PR TITLE
[TRT] Fix reshape, Fix max pool2d for TRT < 5.1, Disable upsample

### DIFF
--- a/python/tvm/relay/tensorrt.py
+++ b/python/tvm/relay/tensorrt.py
@@ -365,8 +365,11 @@ def register_tensorrt_annotations(trt_version, use_implicit_batch=True):
 
     @tvm.ir.register_op_attr("reshape", "target.tensorrt")
     def reshape_whitelist_fn(attrs, args): # pylint: disable=unused-variable
-        if any([x.checked_type.dtype != "float32" for x in args]):
+        if args[0].checked_type.dtype != "float32":
             print("Only float32 inputs are supported for TensorRT.")
+            return False
+        if not isinstance(args[1], Constant):
+            print("reshape: New shape must be a constant.")
             return False
         if any([x < -1 for x in map(int, attrs.newshape)]):
             print("reshape: new shape dims must be explicit.")

--- a/python/tvm/relay/tensorrt.py
+++ b/python/tvm/relay/tensorrt.py
@@ -249,6 +249,9 @@ def register_tensorrt_annotations(trt_version, use_implicit_batch=True):
         if attrs.layout != "NCHW":
             print("nn.max_pool2d: layout is {} but must be NCHW.".format(attrs.layout))
             return False
+        if attrs.ceil_mode and trt_version < (5, 1, 5):
+            print("nn.avg_pool2d: ceil_mode=True requires TensorRT 5.1.5 or greater.")
+            return False
         return True
 
     @tvm.ir.register_op_attr("nn.avg_pool2d", "target.tensorrt")
@@ -458,16 +461,8 @@ def register_tensorrt_annotations(trt_version, use_implicit_batch=True):
 
     @tvm.ir.register_op_attr("image.resize", "target.tensorrt")
     def resize_whitelist_fn(attrs, args): # pylint: disable=unused-variable
-        if any([x.checked_type.dtype != "float32" for x in args]):
-            print("Only float32 inputs are supported for TensorRT.")
-            return False
-        if trt_version < (6, 0, 1):
-            print("image.resize: requires TensorRT version 6.0.1 or higher.")
-            return False
-        if attrs.method != "nearest_neighbor" and attrs.method != "bilinear":
-            return False
-        # TODO(trevmorr): coordinate transform method
-        return True
+        # TODO(trevmorr): Output does not match TVM. Disable.
+        return False
 
     @tvm.ir.register_op_attr("nn.adaptive_max_pool2d", "target.tensorrt")
     def adapative_max_pool2d_whitelist_fn(attrs, args): # pylint: disable=unused-variable
@@ -491,13 +486,8 @@ def register_tensorrt_annotations(trt_version, use_implicit_batch=True):
 
     @tvm.ir.register_op_attr("nn.upsampling", "target.tensorrt")
     def upsampling_whitelist_fn(attrs, args): # pylint: disable=unused-variable
-        if any([x.checked_type.dtype != "float32" for x in args]):
-            print("Only float32 inputs are supported for TensorRT.")
-            return False
-        if trt_version < (6, 0, 1):
-            print("nn.upsampling: requires TensorRT version 6.0.1 or higher.")
-            return False
-        return True
+        # TODO(trevmorr): Output does not match TVM. Disable.
+        return False
 
 class VarReplacer(ExprMutator):
     """

--- a/src/runtime/contrib/tensorrt/tensorrt_builder.cc
+++ b/src/runtime/contrib/tensorrt/tensorrt_builder.cc
@@ -211,9 +211,13 @@ runtime::TrtEngineAndContext TensorRTBuilder::BuildEngine(
 nvinfer1::Weights TensorRTBuilder::GetDLTensorAsWeights(
     DLTensor* dptr, DLDeviceType src_device) {
   CHECK_EQ(dptr->ctx.device_type, src_device);
-  CHECK_EQ(static_cast<int>(dptr->dtype.code), kDLFloat);
+  CHECK(static_cast<int>(dptr->dtype.code) == kDLFloat ||
+        static_cast<int>(dptr->dtype.code) == kDLInt);
+  const auto trt_dtype = static_cast<int>(dptr->dtype.code) == kDLFloat
+                             ? nvinfer1::DataType::kFLOAT
+                             : nvinfer1::DataType::kINT32;
   const size_t weight_bytes = runtime::GetDataSize(*dptr);
-  nvinfer1::Weights weight{nvinfer1::DataType::kFLOAT, nullptr, 0};
+  nvinfer1::Weights weight{trt_dtype, nullptr, 0};
   size_t count = 1;
   for (tvm_index_t i = 0; i < dptr->ndim; ++i) {
     count *= dptr->shape[i];

--- a/src/runtime/contrib/tensorrt/tensorrt_ops.h
+++ b/src/runtime/contrib/tensorrt/tensorrt_ops.h
@@ -832,7 +832,7 @@ class TransposeOpConverter : public TrtOpConverter {
 
 class ReshapeOpConverter : public TrtOpConverter {
  public:
-  ReshapeOpConverter() : TrtOpConverter({kTensor}) {}
+  ReshapeOpConverter() : TrtOpConverter({kTensor, kWeight}) {}
 
   void Convert(AddTrtLayerParams* params) const {
     auto input = params->inputs.at(0).tensor;


### PR DESCRIPTION
* Fix reshape op annotation/conversion after upstream sync
* Upsample and resize ops in TRT don't match TVM's output. Disable for now as they don't improve performance.
* ceil_mode in avg_pool_2d and max_pool_2d is not supported by TRT < 5.1.5. I already had an annotation rule for avg_pool_2d but not for max_pool_2d so I am adding that.