### PR TITLE
[TIDL] Add EliminateCommonSubexpression for TIDL

### DIFF
--- a/python/tvm/relay/backend/contrib/tidl.py
+++ b/python/tvm/relay/backend/contrib/tidl.py
@@ -1415,6 +1415,7 @@ class TIDLCompiler:
         mod['main'] = bind_params_by_name(mod['main'], params)
         mod = relay.transform.FoldConstant()(mod)
         mod['main'] = RemoveMultiplyByOne().visit(mod['main'])
+        mod = relay.transform.EliminateCommonSubexpr()(mod)
 
         #============= Find data layout of the original graph =============
         data_layout = find_data_layout(mod)

--- a/tests/python/relay/test_pass_eliminate_common_subexpr.py
+++ b/tests/python/relay/test_pass_eliminate_common_subexpr.py
@@ -84,6 +84,35 @@ def test_callback():
     z = run_opt_pass(z, transform.EliminateCommonSubexpr(fskip))
     assert tvm.ir.structural_equal(z, expected())
 
+def test_tuple_get_time():
+    def before():
+        x = relay.var('x', shape=(1, 16, 1, 1))
+        var = relay.var('var', shape=(16,))
+        mean = relay.var('mean', shape=(16,))
+        beta = relay.var('beta', shape=(16,))
+        gamma = relay.var('gamma', shape=(16,))
+        BN = relay.op.nn.batch_norm(x, gamma, beta, mean, var, epsilon=1e-5)
+        T1 = BN[0]
+        T2 = BN[0]
+        add = T1 + T2
+        f = relay.Function([x, var, mean, beta, gamma], add)
+        return f
+
+    def expected():
+        x = relay.var('x', shape=(1, 16, 1, 1))
+        var = relay.var('var', shape=(16,))
+        mean = relay.var('mean', shape=(16,))
+        beta = relay.var('beta', shape=(16,))
+        gamma = relay.var('gamma', shape=(16,))
+        BN = relay.op.nn.batch_norm(x, gamma, beta, mean, var, epsilon=1e-5)
+        T1 = BN[0]
+        add = T1 + T1
+        f = relay.Function([x, var, mean, beta, gamma], add)
+        return run_opt_pass(f, transform.InferType())
+
+    z = before()
+    z = run_opt_pass(z, transform.EliminateCommonSubexpr())
+    assert tvm.ir.structural_equal(z, expected())
 
 if __name__ == "__main__":
     test_simple()


### PR DESCRIPTION
Fixes duplicate outputs from certain models.

Previous SE_ResNext50_32x4d:
```
%14 = nn.batch_norm(%13, meta[relay.Constant][16] /* ty=Tensor[(256), float32] */ /* ty=Tensor[(256), float32] */, meta[relay.Constant][17] /* ty=Tensor[(256), float32] */ /* ty=Tensor[(256), float32] */, meta[relay.Constant][18] /* ty=Tensor[(256), float32] */ /* ty=Tensor[(256), float32] */, meta[relay.Constant][19] /* ty=Tensor[(256), float32] */ /* ty=Tensor[(256), float32] */) /* ty=(Tensor[(1, 256, 56, 56), float32], Tensor[(256), float32], Tensor[(256), float32]) */;
%15 = %14.0;
%16 = %14.0;
...
```

With fix:
```
%14 = nn.batch_norm(%13, meta[relay.Constant][16] /* ty=Tensor[(256), float32] */ /* ty=Tensor[(256), float32] */, meta[relay.Constant][17] /* ty=Tensor[(256), float32] */ /* ty=Tensor[(256), float32] */, meta[relay.Constant][18] /* ty=Tensor[(256), float32] */ /* ty=Tensor[(256), float32] */, meta[relay.Constant][19] /* ty=Tensor[(256), float32] */ /* ty=Tensor[(256), float32] */) /* ty=(Tensor[(1, 256, 56, 56), float32], Tensor[(256), float32], Tensor[(256), float32]) */;
%15 = %14.0;
...
```

@jianzhong-xu