### PR TITLE
[Cherry-pick to release-1.3.0][RUNTIME] if a param not in input, we still consume it's data (#5990)

### DIFF
--- a/src/runtime/graph/graph_runtime.cc
+++ b/src/runtime/graph/graph_runtime.cc
@@ -247,7 +247,11 @@ void GraphRuntime::LoadParams(dmlc::Stream* strm) {
   CHECK(size == weight_names_.size()) << "Invalid parameters file format";
   for (size_t i = 0; i < size; ++i) {
     int in_idx = GetInputIndex(weight_names_[i]);
-    if (in_idx < 0) continue;
+    if (in_idx < 0) {
+      NDArray temp;
+      temp.Load(strm);
+      continue;
+    }
     uint32_t eid = this->entry_id(input_nodes_[in_idx], 0);
     CHECK_LT(eid, data_entry_.size());
 


### PR DESCRIPTION
so the read pointer of stream can move forward

Signed-off-by: windclarion <windclarion@gmail.com>

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
