### PR TITLE
[Neo] Get cuda arch from cuda_target_arch rather than querying gpu

### DIFF
--- a/python/tvm/relay/op/strategy/cuda.py
+++ b/python/tvm/relay/op/strategy/cuda.py
@@ -20,6 +20,7 @@ import topi
 import tvm
 from tvm.te import SpecializedCondition
 from tvm.contrib import nvcc
+from tvm.autotvm.env import AutotvmGlobalScope
 from .generic import *
 from .. import op as _op
 from .... import get_global_func
@@ -28,7 +29,6 @@ def get_cross_compile_compute_ver():
     """Temporary workaround to enable cross compiling for GPU in Neo. tvm.gpu(0).compute_version
     will encounter an error if there is no GPU present. Instead, we use compute_version from
     set_cuda_target_arch"""
-    from tvm.autotvm.env import AutotvmGlobalScope
     if AutotvmGlobalScope.current.cuda_target_arch:
         arch = AutotvmGlobalScope.current.cuda_target_arch.split("sm_")[-1]
         return arch[0] + "." + arch[1]

--- a/tests/scripts/task_lint.sh
+++ b/tests/scripts/task_lint.sh
@@ -51,7 +51,7 @@ echo "clang-format check..."
 # check lastest change, for squash merge into master
 ./tests/lint/git-clang-format.sh HEAD~1
 # chekc against origin/master for PRs.
-./tests/lint/git-clang-format.sh origin/dev
+./tests/lint/git-clang-format.sh origin/release-1.3.0
 
 echo "Check codestyle of python code..."
 make pylint


### PR DESCRIPTION
This is a workaround for Neo until TVM's target/attributes system is improved https://discuss.tvm.ai/t/target-and-attributes/6013