### PR TITLE
Changes in tensorrt to detect unsupported types in op args

### DIFF
--- a/python/tvm/relay/tensorrt.py
+++ b/python/tvm/relay/tensorrt.py
@@ -132,7 +132,12 @@ def check_dynamism(args, op_name):
         elif isinstance(arg, Tuple):
             return check_dynamism(arg.fields, op_name)
         else:
-            raise NotImplementedError(type(arg))
+            print(
+                "Arg not supported in TensorRT for ",
+                op_name,
+                type(arg),
+            )
+            return True
     return False
 
 


### PR DESCRIPTION
* Changes in upstream dev causes new arg types like relay.expr.If in ops like reshape

* tensort.py detects those and offloads them to fallback device

Thanks for contributing to TVM!   Please refer to guideline https://tvm.apache.org/docs/contribute/ for useful information and tips. After the pull request is submitted, please request code reviews from [Reviewers](https://github.com/apache/incubator-tvm/blob/master/CONTRIBUTORS.md#reviewers) by @ them in the pull request thread.
