### PR TITLE
Fix batched multiply operations

### DIFF
--- a/python/tvm/relay/tensorrt.py
+++ b/python/tvm/relay/tensorrt.py
@@ -149,6 +149,20 @@ def _register_external_op_helper(op_name, supported=True):
         if any([x.checked_type.dtype != "float32" for x in args]):
             print("Only float32 inputs are supported for TensorRT.")
             return False
+        """
+        TODO (codeislife99): Here we are excluding multiply calculations which get "batched" in implicit batch mode.
+        This leads to wrong or invalid multiply calculations. Since the Neo-service uses implicit batch mode as True
+        this is a temporary workaround. A more generalizable workaround is in the works for a future update. 
+        """
+        if op_name == "multiply":
+            if all(
+                [
+                    list(map(int, arg.checked_type.shape)) in [[300, 64, 7, 7], [300, 1, 1, 1]]
+                    for arg in args
+                ]
+            ):
+                return False
+
         return supported
 
     return _func_wrapper

--- a/python/tvm/relay/tensorrt.py
+++ b/python/tvm/relay/tensorrt.py
@@ -149,11 +149,9 @@ def _register_external_op_helper(op_name, supported=True):
         if any([x.checked_type.dtype != "float32" for x in args]):
             print("Only float32 inputs are supported for TensorRT.")
             return False
-        """
-        TODO (codeislife99): Here we are excluding multiply calculations which get "batched" in implicit batch mode.
-        This leads to wrong or invalid multiply calculations. Since the Neo-service uses implicit batch mode as True
-        this is a temporary workaround. A more generalizable workaround is in the works for a future update. 
-        """
+        # TODO (codeislife99): Here we are excluding multiply calculations which get "batched" in implicit batch mode.
+        # This leads to wrong or invalid multiply calculations. Since the Neo-service uses implicit batch mode as True
+        # this is a temporary workaround. A more generalizable workaround is in the works for a future update. 
         if op_name == "multiply":
             if all(
                 [

--- a/python/tvm/relay/tensorrt.py
+++ b/python/tvm/relay/tensorrt.py
@@ -151,7 +151,7 @@ def _register_external_op_helper(op_name, supported=True):
             return False
         # TODO (codeislife99): Here we are excluding multiply calculations which get "batched" in implicit batch mode.
         # This leads to wrong or invalid multiply calculations. Since the Neo-service uses implicit batch mode as True
-        # this is a temporary workaround. A more generalizable workaround is in the works for a future update. 
+        # this is a temporary workaround. A more generalizable workaround is in the works for a future update.
         if op_name == "multiply":
             if all(
                 [

--- a/python/tvm/relay/tensorrt.py
+++ b/python/tvm/relay/tensorrt.py
@@ -151,7 +151,7 @@ def _register_external_op_helper(op_name, supported=True):
             return False
         # TODO (codeislife99): Here we are excluding multiply calculations which get "batched" in
         # implicit batch mode. This leads to wrong or invalid multiply calculations.
-        # Since the Neo-service uses implicit batch mode as True, this is a temporary workaround.
+        # Since the Neo-service uses implicit batch mode=True, this is a temporary workaround.
         # A more generalizable workaround is in the works for a future update.
         if op_name == "multiply":
             if all(

--- a/python/tvm/relay/tensorrt.py
+++ b/python/tvm/relay/tensorrt.py
@@ -149,9 +149,10 @@ def _register_external_op_helper(op_name, supported=True):
         if any([x.checked_type.dtype != "float32" for x in args]):
             print("Only float32 inputs are supported for TensorRT.")
             return False
-        # TODO (codeislife99): Here we are excluding multiply calculations which get "batched" in implicit batch mode.
-        # This leads to wrong or invalid multiply calculations. Since the Neo-service uses implicit batch mode as True
-        # this is a temporary workaround. A more generalizable workaround is in the works for a future update.
+        # TODO (codeislife99): Here we are excluding multiply calculations which get "batched" in
+        # implicit batch mode. This leads to wrong or invalid multiply calculations.
+        # Since the Neo-service uses implicit batch mode as True, this is a temporary workaround.
+        # A more generalizable workaround is in the works for a future update.
         if op_name == "multiply":
             if all(
                 [


### PR DESCRIPTION
This PR is a temporary workaround for the batched multiply operation because of implicit batch mode set to True. A more general workaround is staged for a future update. 