### PR TITLE
[Frontend][Pytorch] Handle case where output of model is python list

### DIFF
--- a/python/tvm/relay/frontend/pytorch.py
+++ b/python/tvm/relay/frontend/pytorch.py
@@ -2943,8 +2943,11 @@ def from_pytorch(script_module, input_infos, custom_convert_map=None, default_dt
         qnn_torch.add_quant_params(tvm_params, weight_quant_params)
         converter.update_convert_map(qnn_torch.convert_map)
 
-    ret = converter.convert_operators(_get_operator_nodes(graph.nodes()), outputs, ret_name)
+    ret = converter.convert_operators(_get_operator_nodes(graph.nodes()), outputs, ret_name)[0]
+    if isinstance(ret, list):
+        # ListConstruct kept original python list. Convert to tuple.
+        ret = _expr.Tuple(ret)
 
-    mod["main"] = tvm.relay.Function(_analysis.free_vars(ret[0]), ret[0])
+    mod["main"] = tvm.relay.Function(_analysis.free_vars(ret), ret)
 
     return transform.RemoveUnusedFunctions()(mod), tvm_params


### PR DESCRIPTION
prim::ListConstruct converter can make a regular python list when the list is not dynamic:
https://github.com/apache/tvm/blob/main/python/tvm/relay/frontend/pytorch.py#L2436-L2439

If that python list happens to be the output of the whole model, an error would occur when the list is passed to _analysis.free_vars because it only accepts Expr. This PR puts the list in a tuple to solve that.
