### PR TITLE
fix memory leak issue when only using c/c++

### DIFF
--- a/src/runtime/registry.cc
+++ b/src/runtime/registry.cc
@@ -47,12 +47,26 @@ struct Registry::Manager {
 
   Manager() {}
 
+#ifdef TVM_C_API_MEM_MGMT
+  ~Manager() {
+    for (auto& it : fmap) {
+      delete it.second;
+      it.second = nullptr;
+    }
+  }
+#endif
+
   static Manager* Global() {
+#ifdef TVM_C_API_MEM_MGMT
+    static Manager inst;
+    return &inst;
+#else
     // We deliberately leak the Manager instance, to avoid leak sanitizers
     // complaining about the entries in Manager::fmap being leaked at program
     // exit.
     static Manager* inst = new Manager();
     return inst;
+#endif
   }
 };
 


### PR DESCRIPTION
Valgrind has detected possible leak of memory. It is due to `tvm::runtime::Registry::Manager` and `tvm::runtime::Registry::Manager::fmap` are not clean up properly. Original log from valgrind:

```
==24097== 17 bytes in 1 blocks are still reachable in loss record 109 of 1,449
==24097==    at 0x4C3252A: operator new(unsigned long) (vg_replace_malloc.c:342)
==24097==    by 0x10157102: std::__detail::_Map_base<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::unique_ptr<tvm::runtime::Registry, std::default_delete<tvm::runtime::Registry> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::unique_ptr<tvm::runtime::Registry, std::default_delete<tvm::runtime::Registry> > > >, std::__detail::_Select1st, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true>, true>::operator[](std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (in /home/ubuntu/distribution/resources/models/linux-x64/cpu/resnet18_v1/libdlr.so)
==24097==    by 0x101567FC: tvm::runtime::Registry::Register(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool) (in /home/ubuntu/distribution/resources/models/linux-x64/cpu/resnet18_v1/libdlr.so)
==24097==    by 0x100821EB: _GLOBAL__sub_I_c_runtime_api.cc (in /home/ubuntu/distribution/resources/models/linux-x64/cpu/resnet18_v1/libdlr.so)
==24097==    by 0x40108D2: call_init (dl-init.c:72)
==24097==    by 0x40108D2: _dl_init (dl-init.c:119)
==24097==    by 0x401539E: dl_open_worker (dl-open.c:522)
==24097==    by 0x5B871EE: _dl_catch_exception (dl-error-skeleton.c:196)
==24097==    by 0x4014969: _dl_open (dl-open.c:605)
==24097==    by 0x5604F95: dlopen_doit (dlopen.c:66)
==24097==    by 0x5B871EE: _dl_catch_exception (dl-error-skeleton.c:196)
==24097==    by 0x5B8727E: _dl_catch_error (dl-error-skeleton.c:215)
==24097==    by 0x5605744: _dlerror_run (dlerror.c:162)
```