### PR TITLE
[Frontend][Tensorflow] Add TF2 tensorlists and V2 control flow

### DIFF
--- a/python/tvm/relay/frontend/tensorflow2.py
+++ b/python/tvm/relay/frontend/tensorflow2.py
@@ -1,0 +1,484 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name, unused-argument, too-many-lines, len-as-condition, broad-except
+"""Tensorflow2.x graph to relay converter.
+
+If model is constructed using tf2.x API, then use this converter:
+    from tvm.relay.frontend.tensorflow2 import from_tensorflow
+Otherwise use the tf1.x converter:
+    from tvm.relay.frontend.tensorflow import from_tensorflow
+
+"""
+
+import numpy as np
+
+import tvm
+from tvm import relay
+from tvm.relay.transform import InferType
+from tvm.relay.prelude import Prelude
+from tvm.ir import IRModule
+from .. import expr as _expr
+from .. import analysis
+from .. import function as _function
+from ..loops import while_loop as _while_loop
+from .common import infer_shape as _infer_shape
+from .common import infer_type as _infer_type
+
+from tensorflow.python.framework import function_def_to_graph
+
+from .tensorflow2_ops import set_span 
+from .tensorflow2_ops import convert_const_node 
+from .tensorflow2_ops import convert_place_holder
+from .tensorflow2_ops import parse_attr
+from .tensorflow2_ops import convert_map as tf2_convert_map
+from .tensorflow import _convert_map as tf1_convert_map
+
+__all__ = ["from_tensorflow"]
+
+
+def _infer_type_with_prelude(val, prelude):
+    body = _infer_type(val, prelude.mod)
+    return body.checked_type
+
+def _need_prelude_for_shape_inference(op):
+    return "TensorList" in op or "TensorArray" in op
+
+class RelayModule:
+    """ states related to the entire relay module (multiple functions) after converted from tf graphdef
+    """
+    def __init__(self):
+        self.mod = IRModule({}) # relay function and type definitions. defined in tvm/ir/module.py
+        self.params = {}        # for constants (weights) in the entire relay module
+        self.prelude = Prelude(self.mod)  # relay.prelude needed for tensorlist ops
+
+class GraphProto:
+    """Capturing states when converting a tf graph to a single relay function. 
+    """
+    def __init__(self, module):
+        self._module: RelayModule = module
+        self._prelude = self._module.prelude
+        self._params = {}
+        self._nodes = {}
+        self._input_shapes = {}
+        self._tf_node_map = {}
+
+    def from_tensorflow(self, graph, layout="NHWC", shape=None, outputs=None, input_types={}):
+        func = self._get_relay_func(graph, layout=layout, shape=shape, outputs=outputs, input_types=input_types)
+        return func, self._params
+    
+    def _get_relay_func(self, graph, layout="NHWC", shape=None, outputs=None, input_types={}):
+        self._layout = layout
+        for node in graph.node:
+            name = node.name
+            self._tf_node_map[name] = node
+            if node.op == "Placeholder":
+                in_type = None
+                if node.name in input_types:
+                    in_type = input_types[node.name]
+                self._input_shapes[name], self._nodes[name] = convert_place_holder(shape, node, in_type)
+            elif node.op == "Const":
+                sym, param = convert_const_node(node)
+                self._nodes[node.name] = sym
+                if param:
+                    self._params[node.name] = param
+        for node in graph.node:
+            self._backtrack_construct(graph, node.name)
+        return self._func(graph, outputs)
+        
+    def _func(self, graph, outputs):
+        out = []
+        if outputs is None:
+            last_node = graph.node[-1]
+            op = self._nodes[last_node.name.split(":")[0]]
+            if last_node.op == "Exit":
+                assert False # not yet tested
+            else:
+                out = op
+        else:
+            for out_name in outputs:
+                if ":" in out_name:
+                    out_name = out_name.split(":")
+                    out_name, out_num = out_name[0], out_name[-1]
+                    out_num = int(out_num)
+                    out.append(self._nodes[out_name][out_num])
+                else:
+                    out.append(self._nodes[out_name][0])
+
+        if isinstance(out, _expr.TupleWrapper):
+            out = out.astuple()
+        else:
+            out = out[0] if len(out) == 1 else _expr.Tuple(out)
+        fvars = analysis.free_vars(out)
+        func = _function.Function(fvars, out)
+        final_params = {}
+        for fv in fvars:
+            if fv.name_hint in self._params:
+                final_params[fv.name_hint] = self._params[fv.name_hint]
+        self._params = final_params
+        return func
+
+    def _convert_operator(self, graph, op_name, node_name, inputs, attrs):
+        """Convert from Tensorflow operator to relay operator.
+        The converter must specify conversions explicitly for incompatible name, and
+        apply handlers to operator attributes.
+
+        Parameters
+        ----------
+        op_name : str
+            Operator name, such as Conv2D, AvgPool
+        inputs : list of relay.op
+            List of input symbols.
+        attrs : dict
+            Dict of operator attributes
+
+        Returns
+        -------
+        sym : relay.op
+            Converted relay operator
+        """
+
+        if op_name in ["PartitionedCall", "StatefulPartitionedCall"]:
+            sym = _partition_call_operator(self._module, graph, inputs, attrs, self._prelude)
+        elif op_name in ["StatelessIf", "If"]:
+            sym = _convert_if(self._module, graph, inputs, attrs, self._prelude)
+        elif op_name in ["StatelessWhile", "While"]:
+            sym = _convert_loop(self._module, graph, inputs, attrs, node_name, self._tf_node_map, self._prelude)
+        elif op_name in tf2_convert_map:
+            if _need_prelude_for_shape_inference(op_name):
+                sym = tf2_convert_map[op_name](inputs, attrs, self._params, self._prelude)
+            else:
+                sym = tf2_convert_map[op_name](inputs, attrs, self._params, self._module.mod)
+        elif op_name in tf1_convert_map:
+            if _need_prelude_for_shape_inference(op_name):
+                sym = tf1_convert_map[op_name](inputs, attrs, self._params, self._prelude)
+            else:
+                sym = tf1_convert_map[op_name](inputs, attrs, self._params, self._module.mod)
+        else:
+            raise NotImplementedError("Operator {} not implemented.".format(op_name))
+
+        sym = set_span(sym, node_name)
+        return sym
+
+    def _backtrack_construct(self, graph, node_name):
+        """Convert a specific tensorflow node to relay expression.
+
+        If any of its ancestor node is not converted yet, backtrack as
+        far as input node and covert all nodes on the path. resurion is used here.
+
+        This is required when parsing control flow nodes, since the parsing
+        order may not follow the original graph def.
+        
+        to discover input node, current tf node's input is iterated: 
+
+        tensorflow/core/framework/node_def.proto
+            message NodeDef {
+                repeated string input = 3;
+            }
+
+        a node has many inputs (other nodes). each input has the following format: 
+            data input is "node:src_output".  node is the string name. 
+            control input is "^node". 
+
+        Parameters
+        ----------
+        node_name : str
+            node name 
+
+        Returns
+        -------
+        op : relay.Expr
+            Converted relay expression. 
+
+        Examples
+        --------
+        tf expression "x+1" is converted to relay expression:
+            CallNode(Op(add), [Var(x, ty=TensorType([], float32)), Constant(1.0)], (nullptr), [])
+
+        """
+        input_op_name = node_name.split(":")[0].split("^")[-1]
+        if input_op_name not in self._nodes:
+            node = self._tf_node_map[input_op_name]
+            attr = parse_attr(node.attr)
+
+            # attr["_output_shapes"] = self._output_shapes[input_op_name]
+            attr["_node_name"] = node.name
+            attr["_target_layout"] = self._layout
+            inputs = [self._backtrack_construct(graph, iname) for iname in node.input]
+            op = self._convert_operator(graph, node.op, node.name, inputs, attr)
+
+            if isinstance(op, np.ndarray):
+                self._params[node.name] = tvm.nd.array(op)
+                op = [
+                    _expr.var(
+                        node.name,
+                        shape=self._params[node.name].shape,
+                        dtype=self._params[node.name].dtype,
+                    )
+                ]
+            elif isinstance(op, (_expr.Expr, _expr.TupleGetItem)):                
+                op = [op]
+            self._nodes[input_op_name] = op
+
+        out = self._nodes[input_op_name]
+        if isinstance(out, _expr.TupleWrapper):
+            tn = node_name.split(":")
+            tensor_slot = int(tn[1]) if len(tn) > 1 else 0
+            return out[tensor_slot]
+
+        return out[0]
+
+def _partition_call_operator(module, graph, inputs, attr, prelude):
+    """ convert tf PartitionedCall node to a relay function call """
+    node_func_name = attr.get("f").name
+    return _convert_function(module, graph, inputs, attr, node_func_name, prelude)
+
+def _convert_if(module, graph, inputs, attr, prelude):
+    """ Convert tf If/StatelessIf to Relay If """
+    cond_expr = inputs[0]
+    branch_names = [attr.get(x).name for x in ["then_branch", "else_branch"]]
+    then_fn, else_fn = [
+        _convert_function(module, graph, inputs[1:], attr, name, prelude) for name in branch_names
+    ]
+    out = _expr.If(cond_expr, then_fn, else_fn)
+    return out
+
+def _convert_loop(module, graph, inputs, attr, node_name, nodes, prelude):
+    """ convert tf while_loop to Relay loop """
+    input_size = len(inputs)
+    cond_fn_name, body_fn_name = [attr.get(x).name for x in ["cond", "body"]]
+
+    def convert_vars(loop_inputs, input_signature):
+        """ convert inputs to relay vars to be used as loop variables
+            Loop inputs are packed as:
+                [iteration_number, max_iterations, loop_variables...]
+        """
+        new_vars = []
+        for i, v in enumerate(loop_inputs):
+            if isinstance(v, _expr.Constant):
+                vtype = _infer_type(v).checked_type.dtype
+                new_vars.append(_expr.var(input_signature[i].name, shape=(), dtype=vtype))
+            else:
+                vtype = _infer_type_with_prelude(v, prelude)
+                new_vars.append(_expr.var(input_signature[i].name, type_annotation=vtype))
+        return new_vars
+
+    while_func = next(
+        (f for f in graph.library.function if f.signature.name == attr["body"].name),
+        None,
+    )
+    loop_inputs = convert_vars(inputs, while_func.signature.input_arg)
+    # in_shapes = nodes[node_name].attr["output_shapes"].list.shape
+
+    def cond_fn(*loop_inputs):
+        return _convert_function(module, graph, loop_inputs, attr, cond_fn_name, prelude)
+
+    # Define the loop body, in this function we need to unpack loop inputs,
+    # convert the loop subgraph, and pack outputs for the next iteration.
+    def body_fn(*loop_inputs):
+        # Increment loop iteration counter
+        loop_count = loop_inputs[0] + _expr.const(1, dtype='int32')
+        max_count = loop_inputs[1]
+        fn = _convert_function(module, graph, loop_inputs, attr, body_fn_name, prelude)
+
+        # Repack loop variables
+        out = [loop_count, max_count] + [_expr.TupleGetItem(fn, i) for i in range(2, input_size)]
+        return out
+
+    loop = _while_loop(cond_fn, loop_inputs, body_fn)
+    outputs = loop(*inputs)
+    outputs = _expr.TupleWrapper(
+        _expr.Tuple(
+            [
+                _expr.TupleGetItem(outputs, i)
+                for i in range(input_size)
+            ]
+        ),
+        input_size
+    )
+    # pdb.set_trace()
+    return outputs
+
+def _convert_function(module, graph, inputs, attr, node_func_name, prelude, in_shapes=None):
+    """ Convert given tf node to a relay function call
+
+    Parameters
+    ----------
+    module : IRModule 
+        where converted function is stored
+
+    graph: <class 'tensorflow.core.framework.graph_pb2.GraphDef'> 
+        top level tf graphdef 
+
+    inputs : List[tvm.relay.Expr]
+        List of input symbols. Parameters for the function.
+
+    attrs : Dict[tvm.Attrs]
+        Dict of operator attributes.
+
+    node_func_name : str
+        Name of tf2 node to be converted
+
+    Returns
+    -------
+    op : tvm.relay.Expr 
+        <class 'tvm.relay.expr.Call'>
+
+    Examples
+    --------
+    a tf function "x+1", is implemented as a subgraph in the libary section of the graph. this subgraph is converted 
+    to a relay function such as
+        fn (%x: float32) {                                                                                      
+        add(%x, 1f) /* Identity */ 
+        }              
+
+    the subgraph has a function name such as __inference_add_95        
+    the tf function call operator is returned as relay expression, such as:
+        free_var %x: float32;
+        @func___inference_add_95(%x)
+    
+    """
+    func = next(
+        (f for f in graph.library.function if f.signature.name == node_func_name),
+        None,
+    )
+    if func is None:
+        raise Exception("Function not found - {}".format(node_func_name))        
+    devices = set(node.device for node in func.node_def)
+    if len(devices) > 1:
+        raise Exception("node_def in function {} contains > 1 types of devices {}".format(node_func_name, devices))
+    
+    func_input_shapes = in_shapes
+    if func_input_shapes is None:
+        func_input_shapes = func.attr["_input_shapes"].list.shape
+    subgraph, _ = function_def_to_graph.function_def_to_graph_def(func, func_input_shapes)
+    # preserve library functions in subgraphs to make them available to nested functions
+    for fn in graph.library.function:
+        subgraph.library.function.add().CopyFrom(fn)
+
+    # Computing subgraph's input shape and type dictionaries
+    input_expr_dict = {}
+    input_types = {}
+    for f_arg, input in zip(func.signature.input_arg, inputs):
+        input_expr_dict[f_arg.name] = input
+        input_types[f_arg.name] = _infer_type_with_prelude(input, prelude)
+
+    func_name = "func_{}".format(func.signature.name)
+    try:
+        global_func = module.mod[func_name]
+        sub_func = global_func
+        sub_params = module.params
+    except ValueError:
+        # Construct relay nodes from the subgraph
+        g1 = GraphProto(module)
+        output_sig = [func.ret[f.name] for f in func.signature.output_arg]
+
+        # TODO: unify prelude and main IRModules
+        sub_func, sub_params = g1.from_tensorflow(subgraph, outputs=output_sig, input_types=input_types)
+        module.params.update(sub_params)
+        func_expr = _function.Function(sub_func.params, sub_func.body)
+        global_func = tvm.relay.GlobalVar(func_name)
+        module.mod[global_func] = func_expr
+        module.mod = InferType()(module.mod)
+        prelude.mod = module.mod
+
+    param_exprs = []
+    for param_expr in sub_func.params:
+        # sub_params is subset of sub_func.params
+        param_name = param_expr.vid.name_hint
+        if param_name in input_expr_dict.keys():
+            param_exprs.append(input_expr_dict[param_name])
+        elif param_name in sub_params.keys():
+            param_exprs.append(param_expr)
+        else:
+            raise Exception("Input parameter {} not found".format(param_name))
+
+    sb = tvm.relay.scope_builder.ScopeBuilder()
+    loop_ret = global_func(*param_exprs)
+    sb.ret(loop_ret)
+    ret = sb.get()
+    return ret
+
+def from_tensorflow(graph_def, layout="NHWC", shape=None, outputs=None):
+    """convert tensorflow2.x graph into relay function.
+
+    Parameters
+    ----------
+    graph_def : must be frozen graph (no variables allowed). 
+        Placeholders are assumed to be inputs to the graph.
+
+        tensorflow/core/framework/graph.proto
+            message GraphDef {
+              repeated NodeDef node = 1;
+              FunctionDefLibrary library = 2;
+            }
+        tensorflow/core/framework/function.proto
+            message FunctionDef {
+              repeated NodeDef node_def = 3;
+            }
+
+    layout : str
+        The layout for the model.
+
+    shape : List[str, List[int]]
+        Input to the model. It is a key and shape vector mapping. Applies to placeholders. 
+
+    outputs : List[str]
+        The list of output nodes. The last node is treated as the output if not
+        specified.
+
+    Returns
+    -------
+    mod : tvm.IRModule
+        The module that optimizations will be performed on.
+
+    params : dict of str to tvm.nd.NDArray
+        Dict of converted parameters stored in tvm.nd.NDArray format. 
+
+    Examples
+    --------
+    "x+1" tf module where x has a shape of (2,2) is converted as follows:
+
+    mod : tvm.IRModule
+        def @func___inference_add_95(%x: Tensor[(2, 2), float32], %add/y: Tensor[(2, 2), float32]) -> Tensor[(2, 2), float32] {
+        add(%x, %add/y) /* Identity */ /* ty=Tensor[(2, 2), float32] */
+        }
+
+        def @main(%x1: Tensor[(2, 2), float32], %add/y1: Tensor[(2, 2), float32]) {
+        @func___inference_add_95(%x1, %add/y1) /* Identity */
+        }
+
+    params : dict of str to tvm.nd.NDArray
+        {'add/y': <tvm.nd.NDArray shape=(2, 2), cpu(0)>
+
+    """
+
+    # func = graph_def.library.function[0]
+    # inshape = func.attr["_input_shapes"].list.shape
+    # import pdb; pdb.set_trace()
+    # x, _ = function_def_to_graph.function_def_to_graph_def(func, inshape)
+    module = RelayModule()
+    # x, _ = function_def_to_graph.function_def_to_graph_def(func, inshape)
+    g = GraphProto(module)
+    func, params = g.from_tensorflow(graph_def, layout, shape, outputs)
+    module.mod["main"] = func
+    module.params.update(params)
+    # print("=======Mod========")
+    # print(module.mod)
+    # print("=======Params keys========")
+    # print(module.params.keys())
+    # print("===============")
+    return module.mod, module.params

--- a/python/tvm/relay/frontend/tensorflow2_ops.py
+++ b/python/tvm/relay/frontend/tensorflow2_ops.py
@@ -944,7 +944,7 @@ convert_map = {
     # "Softmax": _softmax(),
     # "Sub": _elemwise("subtract"),
     # "StridedSlice": _stridedSlice(),
-    # "Shape": _shape(),
+    "Shape": _shape(),
     # "Split": _split(False),
     # "Squeeze": _squeeze(),
 

--- a/python/tvm/relay/frontend/tensorflow2_ops.py
+++ b/python/tvm/relay/frontend/tensorflow2_ops.py
@@ -1,0 +1,1131 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name, unused-argument, too-many-lines, len-as-condition, broad-except
+"""Tensorflow2.x to relay converter ops and helper"""
+
+import tvm
+from .common import get_relay_op
+from .. import expr as _expr
+from .. import op as _op
+
+import numpy as np
+from tensorflow.python.framework import tensor_util
+from tensorflow.python.framework import dtypes
+
+
+from tvm.topi.utils import get_const_tuple
+from tvm.relay.prelude import Prelude, StaticTensorArrayOps, get_tensor_array_shape, TensorArrayOps
+from ..ty import Any, TensorType
+from .common import infer_value as _infer_value
+from .common import AttrCvt
+from .common import infer_shape as _infer_shape
+from .common import infer_type as _infer_type
+from .common import infer_channels as _infer_channels
+
+def _infer_type_with_prelude(val, prelude):
+    body = _infer_type(val, prelude.mod)
+    return body.checked_type
+
+def _get_pad_pair(input1d, kernel1d, stride1d):
+    if input1d % stride1d == 0:
+        pad = max(kernel1d - stride1d, 0)
+    else:
+        pad = max(kernel1d - (input1d % stride1d), 0)
+
+    pad_before = pad // 2
+    pad_after = pad - pad_before
+
+    return [pad_before, pad_after]
+
+def _get_param(params, input_node):
+    if isinstance(input_node, _expr.Constant):
+        return np.atleast_1d(input_node.data.asnumpy())
+    return params[input_node.name_hint].asnumpy()
+
+
+def _get_num_param(params, input_node):
+    return _get_param(params, input_node).item()
+
+
+def _get_list_param(params, input_node):
+    return _get_param(params, input_node).tolist()
+
+
+def _get_tuple_param(params, input_node):
+    return tuple(_get_param(params, input_node))
+
+def _get_more_static_shape(shape0, shape1):
+    """Compare two shapes with the same rank,
+    and return the one with fewer symbolic dimension.
+    """
+    assert len(shape0) == len(shape1)
+    num_sym_dim0 = 0
+    num_sym_dim1 = 0
+    for dim0, dim1 in zip(list(shape0), list(shape1)):
+        if not isinstance(dim0, int):
+            num_sym_dim0 += 1
+        if not isinstance(dim1, int):
+            num_sym_dim1 += 1
+
+    if num_sym_dim0 < num_sym_dim1:
+        return shape0
+    return shape1
+
+def _bias_add():
+    def _impl(inputs, attr, params, mod):
+        # Must expand for proper broadcasting in NCHW.
+        if "data_format" in attr and attr["data_format"].decode("utf-8") == "NCHW":
+            bias = _op.reshape(inputs[1], newshape=(1, -1, 1, 1))
+        else:
+            bias = inputs[1]
+        return _op.add(inputs[0], bias)
+
+    return _impl
+
+def _squeeze():
+    def _impl(inputs, attr, params, mod):
+        if len(attr["squeeze_dims"]) == 0:
+            attr["squeeze_dims"] = None
+        return AttrCvt(op_name="squeeze", transforms={"squeeze_dims": "axis"}, ignores=["T"])(
+            inputs, attr
+        )
+
+    return _impl
+
+def _where():
+    def _impl(inputs, attr, params, mod):
+        if len(inputs) == 1:
+            return AttrCvt(op_name="argwhere")(inputs, attr)
+        return AttrCvt(op_name="where")(inputs, attr)
+
+    return _impl
+
+def _gather():
+    def _impl(inputs, attr, params, mod):
+        if len(inputs) > 2:
+            axis = _get_num_param(params, inputs.pop(2))
+        else:
+            axis = 0
+        if int(attr.get("batch_dims", 0)) != 0:
+            raise tvm.error.OpAttributeUnImplemented("Attribute batch_dims is not supported")
+        new_input = inputs[0:2]
+        return AttrCvt(
+            op_name="take",
+            extras={"axis": tvm.tir.const(axis, "int32")},
+            ignores=["Tindices", "Tparams", "validate_indices", "Taxis", "_class", "batch_dims"],
+        )(new_input, attr)
+
+    return _impl
+
+def _softmax():
+    def _impl(inputs, attr, params, mod):
+        return AttrCvt(op_name="softmax", transforms={"axis": ("axis", 1)})([inputs[0]], attr)
+
+    return _impl
+
+def _conv(opname):
+    def _impl(inputs, attr, params, mod):
+        attr["data_format"] = attr["data_format"].decode("utf-8")
+        flip_layout = False
+
+        if opname == "conv_transpose" and attr["data_format"] == "NHWC":
+            # transform to NCHW for TVM backend compatible and set 'flip_layout'
+            # to have output flip back to NHWC
+            inputs[2] = _op.transpose(inputs[2], axes=(0, 3, 1, 2))
+            attr["strides"][1], attr["strides"][2], attr["strides"][3] = (
+                attr["strides"][3],
+                attr["strides"][1],
+                attr["strides"][2],
+            )
+
+            attr["data_format"] = "NCHW"
+
+            # Check whether output shapes attribute is set and not None
+            if (
+                opname == "conv_transpose"
+                and len(attr["_output_shapes"]) > 0
+                and attr["_output_shapes"][0]
+            ):
+                tmp_shape = attr["_output_shapes"][0]
+                tmp_shape = [tmp_shape[ii] for ii in (0, 3, 1, 2)]
+                attr["_output_shapes"][0] = tmp_shape
+
+            flip_layout = True
+
+        inputs_data = inputs[0] if opname != "conv_transpose" else inputs[2]
+
+        # NCHW Layout require weights transpose
+        weights_shape = _infer_shape(inputs[1], mod)
+        if attr["data_format"] == "NCHW":
+            tmp_shape = weights_shape
+            if opname in ["conv", "conv_transpose"]:
+                tmp_shape = [tmp_shape[ii] for ii in (3, 2, 0, 1)]
+                inputs[1] = _op.transpose(inputs[1], axes=(3, 2, 0, 1))
+            else:
+                tmp_shape = [tmp_shape[ii] for ii in (2, 3, 0, 1)]
+                inputs[1] = _op.transpose(inputs[1], axes=(2, 3, 0, 1))
+            weights_shape = tmp_shape
+
+        input_shape = _infer_shape(inputs_data, mod)
+        if attr["_target_layout"] == "NCHW" and attr["data_format"] == "NHWC":
+            input_shape = [input_shape[ii] for ii in (0, 3, 1, 2)]
+            inputs_data = _op.transpose(inputs_data, axes=(0, 3, 1, 2))
+            if opname in ["conv", "conv_transpose"]:
+                weights_shape = [weights_shape[ii] for ii in (3, 2, 0, 1)]
+                inputs[1] = _op.transpose(inputs[1], axes=(3, 2, 0, 1))
+            else:
+                weights_shape = [weights_shape[ii] for ii in (2, 3, 0, 1)]
+                inputs[1] = _op.transpose(inputs[1], axes=(2, 3, 0, 1))
+
+            attr["data_format"] = "NCHW"
+            attr["strides"] = [attr["strides"][ii] for ii in (0, 3, 1, 2)]
+            flip_layout = True
+
+        if attr["data_format"] == "NHWC":
+            in_channels = input_shape[3]
+            kernel_h, kernel_w, _, depth_mult = weights_shape
+            attr["kernel_shape"] = (weights_shape[0], weights_shape[1])
+            if opname == "conv":
+                attr["channels"] = weights_shape[3]
+            elif opname == "conv_transpose":
+                attr["channels"] = weights_shape[2]
+            else:
+                attr["channels"] = input_shape[3] * depth_mult
+
+            if "dilations" in attr:
+                attr["dilations"] = (attr["dilations"][1], attr["dilations"][2])
+            attr["strides"] = (attr["strides"][1], attr["strides"][2])
+        elif attr["data_format"] == "NCHW":
+            in_channels = input_shape[1]
+            _, depth_mult, kernel_h, kernel_w = weights_shape
+            attr["kernel_shape"] = (weights_shape[2], weights_shape[3])
+            if opname == "conv":
+                attr["channels"] = weights_shape[0]
+            elif opname == "conv_transpose":
+                attr["channels"] = weights_shape[1]
+            else:
+                attr["channels"] = input_shape[1] * depth_mult
+                if attr["channels"] < 0:
+                    attr["channels"] *= -1
+
+            if "dilations" in attr:
+                attr["dilations"] = (attr["dilations"][2], attr["dilations"][3])
+            attr["strides"] = (attr["strides"][2], attr["strides"][3])
+        else:
+            msg = 'Value {} in attribute "data_format" of operator Conv is ' "not valid."
+            raise tvm.error.OpAttributeInvalid(msg.format(attr["data_format"]))
+
+        if opname == "depthwise":
+            attr["groups"] = in_channels
+
+        # Fix padding
+        attr["padding"] = attr["padding"].decode("utf-8")
+
+        if attr["padding"] == "VALID":
+            attr["padding"] = [0, 0]
+        elif attr["padding"] == "SAME":
+            stride_h, stride_w = attr["strides"]
+            kernel_h, kernel_w = attr["kernel_shape"]
+
+            pdata_shape = input_shape
+            # Check whether output shapes attribute is set and not None
+            if (
+                opname == "conv_transpose"
+                and len(attr["_output_shapes"]) > 0
+                and attr["_output_shapes"][0]
+            ):
+                pdata_shape = attr["_output_shapes"][0]
+
+            if attr["data_format"] == "NHWC":
+                in_h = pdata_shape[1]
+                in_w = pdata_shape[2]
+            else:
+                in_h = pdata_shape[2]
+                in_w = pdata_shape[3]
+
+            dilation_h = attr["dilations"][0]
+            dilation_w = attr["dilations"][1]
+            dilated_kernel_h = (kernel_h - 1) * dilation_h + 1
+            dilated_kernel_w = (kernel_w - 1) * dilation_w + 1
+            pad_v = _get_pad_pair(in_h, dilated_kernel_h, stride_h)
+            pad_h = _get_pad_pair(in_w, dilated_kernel_w, stride_w)
+
+            attr["padding"] = [pad_v[0], pad_h[0], pad_v[1], pad_h[1]]
+        else:
+            msg = 'Value {} in attribute "padding" of operator Conv is not ' "valid."
+            raise tvm.error.OpAttributeInvalid(msg.format(attr["padding"]))
+
+        if "kernel_layout" not in attr:
+            if opname in ["conv", "conv_transpose"]:
+                attr["kernel_layout"] = "HWIO" if attr["data_format"] == "NHWC" else "OIHW"
+            else:
+                attr["kernel_layout"] = "HWOI" if attr["data_format"] == "NHWC" else "OIHW"
+
+        # Ignore the new attributes from TF2.0, for now.
+        out = AttrCvt(
+            op_name=_dimension_picker(
+                "conv", surfix="_transpose" if opname == "conv_transpose" else ""
+            ),
+            ignores=["explicit_paddings"],
+            transforms={
+                "kernel_shape": "kernel_size",
+                "data_format": "data_layout",
+                "dilations": ("dilation", (0, 0)),
+                "group": ("groups", 1),
+            },
+            custom_check=_dimension_constraint(),
+        )([inputs_data, inputs[1]], attr)
+
+        if flip_layout:
+            out = _op.transpose(out, axes=(0, 2, 3, 1))
+
+        return out
+
+    return _impl
+
+def _cast():
+    def _impl(inputs, attr, params, mod):
+        return inputs[0].astype(attr["DstT"].name)
+
+    return _impl
+
+def _dimension_picker(prefix, surfix=""):
+    def _impl(attr):
+        kernel = attr["kernel_shape"]
+        if len(kernel) == 2:
+            return prefix + "2d" + surfix
+        if len(kernel) == 3:
+            return prefix + "3d" + surfix
+        raise tvm.error.OpAttributeInvalid(
+            "Only 2D or 3D kernels are supported for operator {}".format(prefix + "2d or 3d")
+        )
+
+    return _impl
+
+
+def _dimension_constraint():
+    def _dim_check(attrs):
+        if len(attrs["kernel_shape"]) in (2, 3):
+            return True
+        return False
+
+    return _dim_check, "Only 2d or 3d kernel supported."
+
+
+def _elemwise(name):
+    def _impl(inputs, attr, params, mod):
+        assert len(inputs) == 2, "{} take 2 inputs, {} given".format(name, len(inputs))
+        return get_relay_op(name)(*inputs)
+
+    return _impl
+
+def identity():
+    def _impl(inputs, attr, params, mod):
+        return inputs[0]
+
+    return _impl
+
+
+def _matmul():
+    def _impl(inputs, attr, params, mod):
+        channels = _infer_channels(inputs[1], not attr["transpose_b"])
+        if attr["transpose_a"]:
+            inputs[0] = _op.transpose(inputs[0], axes=(1, 0))
+        if not attr["transpose_b"]:
+            inputs[1] = _op.transpose(inputs[1], axes=(1, 0))
+        return AttrCvt(
+            op_name="dense", extras={"units": channels}, ignores=["transpose_a", "transpose_b", "T"]
+        )(inputs, attr)
+
+    return _impl
+
+def _no_op():
+    def _impl(inputs, attr, params, mod):
+        # ToDo: This should really be an op that returns nothing, which could
+        # be represented as an empty tuple. It turns out that TVM
+        # infrastructure doesn't like running functions that return None and
+        # also don't like running functions that return an empty tuple. So it
+        # doesn't work, but it should be made to work and then this could be
+        # improved. In the mean time, it is hard to imagine a case where it
+        # matters in any real way that a no-op is converted to a constant 0.
+        return tvm.relay.const(0)
+
+    return _impl
+
+
+def _pooling(name):
+    def _impl(inputs, attr, params, mod):
+
+        attr["data_format"] = attr["data_format"].decode("utf-8")
+        flip_layout = False
+
+        input_shape = _infer_shape(inputs[0], mod)
+
+        if attr["data_format"] == "NHWC":
+            attr["kernel_shape"] = (attr["ksize"][1], attr["ksize"][2])
+            attr["strides"] = (attr["strides"][1], attr["strides"][2])
+        elif attr["data_format"] == "NCHW":
+            attr["kernel_shape"] = (attr["ksize"][2], attr["ksize"][3])
+            attr["strides"] = (attr["strides"][2], attr["strides"][3])
+        else:
+            msg = 'Value {} of attribute "data_format" of operator Pooling ' "is not valid."
+            raise tvm.error.OpAttributeInvalid(msg.format(attr["data_format"]))
+
+        if attr["_target_layout"] == "NCHW" and attr["data_format"] == "NHWC":
+            tmp_shape = _infer_shape(inputs[0], mod)
+            input_shape = [tmp_shape[ii] for ii in (0, 3, 1, 2)]
+            inputs[0] = _op.transpose(inputs[0], axes=(0, 3, 1, 2))
+            attr["data_format"] = "NCHW"
+            flip_layout = True
+
+        # Fix padding
+        attr["padding"] = attr["padding"].decode("utf-8")
+
+        if attr["padding"] == "VALID":
+            attr["padding"] = [0, 0]
+        elif attr["padding"] == "EXPLICIT":
+            paddings = attr["explicit_paddings"]
+            assert len(paddings) == 8
+            if flip_layout or attr["data_format"] == "NHWC":
+                attr["padding"] = [paddings[2], paddings[4], paddings[3], paddings[5]]
+            else:
+                attr["padding"] = [paddings[4], paddings[6], paddings[5], paddings[7]]
+        elif attr["padding"] == "SAME":
+            stride_h, stride_w = attr["strides"]
+            kernel_h, kernel_w = attr["kernel_shape"]
+            if attr["data_format"] == "NHWC":
+                in_h = input_shape[1]
+                in_w = input_shape[2]
+            else:
+                in_h = input_shape[2]
+                in_w = input_shape[3]
+
+            pad_v = _get_pad_pair(in_h, kernel_h, stride_h)
+            pad_h = _get_pad_pair(in_w, kernel_w, stride_w)
+
+            attr["padding"] = [pad_v[0], pad_h[0], pad_v[1], pad_h[1]]
+        else:
+            msg = 'Value {} in attribute "padding" of operator Pooling is ' "not valid."
+            raise tvm.error.OpAttributeInvalid(msg.format(attr["padding"]))
+
+        if name == "avg_pool":
+            attr["count_include_pad"] = False
+
+        out = AttrCvt(
+            op_name=_dimension_picker(name),
+            transforms={"kernel_shape": "pool_size", "data_format": "layout"},
+            ignores=["ksize", "explicit_paddings"],
+            extras={"ceil_mode": False},
+            custom_check=_dimension_constraint(),
+        )(inputs, attr)
+
+        if flip_layout:
+            out = _op.transpose(out, axes=(0, 2, 3, 1))
+
+        return out
+
+    return _impl
+
+def _broadcast(name):
+    def _impl(inputs, attr, params, mod):
+        return AttrCvt(op_name=name, ignores=["name", "incompatible_shape_error", "Tidx"])(
+            inputs, attr
+        )
+
+    return _impl
+
+
+def _reshape():
+    def _impl(inputs, attr, params, mod):
+        pop_node = inputs.pop(1)
+
+        try:
+            shape_arg = _get_tuple_param(params, pop_node)
+        except AttributeError:
+            # Shape operator is already pruned, hence
+            # try to infer shape by precompute prune if possible.
+            try:
+                params_new = _infer_value(pop_node, params, mod)
+                shape_arg = tuple(params_new.asnumpy().astype("int32").flatten())
+            except Exception:
+                # Deal with symbolic shape case.
+                if isinstance(pop_node, _expr.Call) and "shape_of" in str(pop_node.op):
+                    # shape_of is the direct ancestor.
+                    return _op.reshape_like(inputs[0], pop_node.args[0])
+                shape_arg = pop_node
+
+        return AttrCvt(op_name="reshape", extras={"newshape": shape_arg}, ignores=["Tshape"])(
+            inputs, attr
+        )
+
+    return _impl
+
+def _fused_batch_norm():
+    def _impl(inputs, attr, params, mod):
+        # Tensorflow: (data, gamma, beta, moving_mean, moving_variance)
+        # Relay:       (data, gamma, beta, moving_mean, moving_varience)
+        assert len(inputs) == 5
+        axis = 3
+        need_cast = False
+
+        if "data_format" in attr:
+            attr["data_format"] = attr["data_format"].decode("utf-8")
+            if attr["data_format"] == "NCHW":
+                axis = 1
+        if "U" in attr and attr["U"].name != attr["T"].name:
+            need_cast = True
+            inputs[0] = _op.cast(inputs[0], dtype=attr["U"].name)
+        # Check if mean and variance are empty
+        # If so, replace them with Mean and Variance Ops
+        # For run-time calculation
+        moving_mean_shape = [int(n) for n in inputs[3].type_annotation.shape]
+        moving_variance_shape = [int(n) for n in inputs[4].type_annotation.shape]
+        if moving_mean_shape[0] == 0 and moving_variance_shape[0] == 0:
+            inputs[3] = _op.mean(inputs[0], axis=axis, keepdims=False, exclude=True)
+            inputs[4] = _op.variance(inputs[0], axis=axis, keepdims=False, exclude=True)
+        out = AttrCvt(
+            op_name="batch_norm",
+            transforms={"scale_after_normalization": "scale", "variance_epsilon": "epsilon"},
+            extras={"axis": axis},
+            ignores=["data_format", "U", "exponential_avg_factor"],
+            disables=["momentum"],
+        )(inputs, attr)
+
+        if need_cast:
+            out = _expr.TupleGetItem(out.astuple(), 0)
+            out = _op.cast(out, dtype=attr["T"].name)
+        return out
+
+    return _impl
+
+def _floormod():
+    def _impl(inputs, attr, params, mod):
+        assert len(inputs) == 2
+        return AttrCvt("floor_mod")(inputs, attr)
+
+    return _impl
+
+def _logical(name):
+    def _impl(inputs, attr, params, mod):
+        return AttrCvt(op_name=name)(inputs, attr)
+
+    return _impl
+
+def _stridedSlice():
+    def _impl(inputs, attr, params, mod):
+        """Strided Slice.
+        Operator description: https://www.tensorflow.org/api_docs/python/tf/strided_slice
+        Tensorflow mask validation: https://github.com/tensorflow/tensorflow/blob/master/
+        tensorflow/core/util/strided_slice_op.cc#L147-L368
+        """
+        try:
+            begin = _get_list_param(params, inputs[1])
+        except (IndexError, KeyError, AttributeError):
+            begin = _infer_value(inputs[1], params, mod).asnumpy().tolist()
+        end = _get_list_param(params, inputs[2])
+        stride = _get_list_param(params, inputs[3])
+
+        begin_mask = int(attr.get("begin_mask", 0))
+        end_mask = int(attr.get("end_mask", 0))
+        ellipsis_mask = int(attr.get("ellipsis_mask", 0))
+        new_axis_mask = int(attr.get("new_axis_mask", 0))
+        shrink_axis_mask = int(attr.get("shrink_axis_mask", 0))
+        in_type = _infer_type(inputs[0], mod)
+        data_shape = get_const_tuple(in_type.checked_type.shape)
+        data_dim = len(data_shape)
+        stride_dim = len(stride)
+
+        # This is a special routine to handle strided_slice after shape_of.
+        # We need this since in some cases we want to do strided_slice on
+        # a partial symbolic shape, such as (1, ?), and get a static shape
+        # (1,). Directly slice on shape_of will result in fully dynamic shape.
+        # TODO(kevinthesun): Can we generalize this process with partial eval?
+        if isinstance(inputs[0], _expr.Call) and inputs[0].op == _op.get("shape_of"):
+            bg = begin[0]
+            ed = end[0]
+            st = stride[0]
+
+            if ed <= 0 < st:
+                ed += data_shape[0]
+
+            in_shape = _infer_shape(inputs[0].args[0], mod)
+            dtype = in_type.checked_type.dtype
+            out_data = []
+            idx = bg
+            while idx < ed:
+                if isinstance(in_shape[idx], int):
+                    out_data.append(in_shape[idx])
+                else:
+                    break
+                idx += st
+
+            # Only return when in_shape is fully static in the range from begin to end.
+            if idx >= ed:
+                ret = _expr.const(out_data, dtype)
+                if shrink_axis_mask:
+                    ret = _op.squeeze(ret)
+
+                return ret
+
+        def _transform_mask(stride_dim, ellipsis_mask):
+            """Handle mask inputs to create new begin, end, stride and output shape"""
+            m_begin = [0] * data_dim
+            m_end = [0] * data_dim
+            m_stride = [0] * data_dim
+            fshape_indices = []
+            # Count new axis after ellipsis_mask, consider while applying ellipsis_mask.
+            ellipsis_seen = False
+            new_axes_after_ellipsis = 0
+            for i in range(stride_dim):
+                mask = 1 << i
+                if ellipsis_seen and (mask & new_axis_mask) != 0:
+                    new_axes_after_ellipsis += 1
+                if (mask & ellipsis_mask) != 0:
+                    ellipsis_seen = True
+            if not ellipsis_seen:
+                # Used later for extending the stride attributes in the below loop.
+                ellipsis_mask |= 1 << stride_dim
+                stride_dim += 1
+            final_index = 0
+            for index in range(stride_dim):
+                mask = 1 << index
+                if mask & ellipsis_mask:
+                    # Identify the end index for applying ellipsis_mask
+                    to_index = min(
+                        ((data_dim - (stride_dim - index)) + 1 + new_axes_after_ellipsis), data_dim
+                    )
+                    for i in range(final_index, to_index):
+                        m_begin[final_index] = 0
+                        m_end[final_index] = data_shape[final_index]
+                        m_stride[final_index] = 1
+                        fshape_indices.append(final_index)
+                        final_index += 1
+                elif mask & new_axis_mask:
+                    fshape_indices.append(-1)
+                elif not mask & new_axis_mask:
+                    if final_index == len(m_begin):
+                        break
+                    if mask & begin_mask:
+                        m_begin[final_index] = -1 if stride[index] < 0 else 0
+                    elif begin[index]:
+                        m_begin[final_index] = begin[index]
+                    if mask & end_mask:
+                        m_end[final_index] = (
+                            -(data_shape[final_index] + 1)
+                            if stride[index] < 0
+                            else data_shape[final_index]
+                        )
+                    elif end[index]:
+                        m_end[final_index] = end[index]
+                    m_stride[final_index] = stride[index]
+                    if mask & shrink_axis_mask:
+                        # Tensorflow make axis with shrink_axis_mask as dimension 1
+                        m_begin[final_index] = (
+                            data_shape[final_index] + begin[index]
+                            if begin[index] < 0
+                            else begin[index]
+                        )
+                        m_end[final_index] = begin[index] + 1
+                        m_stride[final_index] = 1
+                        fshape_indices.append(-2)
+                    else:
+                        fshape_indices.append(final_index)
+
+                    final_index += 1
+            return m_begin, m_end, m_stride, fshape_indices
+
+        fshape_indices = None
+        if begin_mask or end_mask or ellipsis_mask or new_axis_mask or shrink_axis_mask:
+            begin, end, stride, fshape_indices = _transform_mask(stride_dim, ellipsis_mask)
+        out = _op.strided_slice(inputs[0], begin=begin, end=end, strides=stride)
+        out_shape = _infer_shape(out, mod=mod)
+        if not fshape_indices:
+            fshape_indices = range(len(out_shape))
+
+        # Create final output shape.
+        final_output = []
+        for gather_index in fshape_indices:
+            if gather_index == -1:
+                final_output.append(1)
+            elif gather_index == -2:
+                pass
+            else:
+                final_output.append(out_shape[gather_index])
+
+        if not final_output:
+            if not shrink_axis_mask:
+                ret = out
+            else:
+                final_shape = []
+                for dim in out_shape:
+                    if dim != 1:
+                        final_shape.append(dim)
+                if len(final_shape) == 0:
+                    ret = _op.squeeze(out)
+                else:
+                    # We need reshape to handle dynamic shape.
+                    ret = _op.reshape(out, newshape=tuple(final_shape))
+        else:
+            ret = _op.reshape(out, newshape=tuple(final_output))
+        return ret
+
+    return _impl
+
+def _shape():
+    def _impl(inputs, attr, params, mod):
+        # input_shape = _infer_shape(inputs[0], mod)
+        # not yet tested
+        # is_symbolic_shape = False
+        # for axis in input_shape:
+        #     if not isinstance(axis, (int, tvm.tir.IntImm)):
+        #         is_symbolic_shape = True
+        #         break
+
+        ret = _op.shape_of(inputs[0], dtype=attr["out_type"].name)
+
+        # is_symbolic_shape is not tested:
+
+        return ret
+
+    return _impl
+
+def _fill():
+    def _impl(inputs, attr, params, mod):
+        try:
+            output_shape = _infer_value(inputs[0], params, mod).asnumpy().tolist()
+        except Exception:
+            output_shape = inputs[0]
+
+        return _op.full(inputs[1], output_shape, attr["T"].name)
+
+    return _impl
+
+def _pack():
+    def _impl(inputs, attr, params, mod):
+        axis = int(attr["axis"])
+        inputs_reshaped = [_op.expand_dims(i, axis=axis, num_newaxis=1) for i in inputs]
+        return _op.concatenate(inputs_reshaped, axis)
+
+    return _impl
+
+def _split(has_size_vector):
+    # TF documentation https://www.tensorflow.org/api_docs/python/tf/split
+    def _impl(inputs, attr, params, mod):
+        try:
+            # order and number of inputs are different:
+            # if has_size_vector:
+            #     https://www.tensorflow.org/api_docs/cc/class/tensorflow/ops/split-v
+            # else:
+            #     https://www.tensorflow.org/api_docs/cc/class/tensorflow/ops/split
+
+            # in addition, `axis` and `num_or_size_splits` can be tensors in TensorFlow,
+            # we can only support constants
+            if has_size_vector:
+                input_node_index = 0
+                input_axis_index = 2
+                size_splits = _get_param(params, inputs[1])
+                section_beginnings = np.cumsum(size_splits)[:-1]
+                indices_or_sections = tuple(section_beginnings)
+            else:
+                input_node_index = 1
+                input_axis_index = 0
+                indices_or_sections = attr["num_split"]
+            input_node = inputs[input_node_index]
+            axis_input_value = _get_num_param(params, inputs[input_axis_index])
+        except (IndexError, KeyError, AttributeError):
+            raise TypeError(
+                "Unsupported argument for split: `axis` and `num_or_size_splits` "
+                "should be constants"
+            )
+        return _op.split(
+            input_node, indices_or_sections=indices_or_sections, axis=int(axis_input_value)
+        )
+
+    return _impl
+
+
+def _concatV2():
+    def _impl(inputs, attr, params, mod):
+        pop_node = inputs.pop(len(inputs) - 1)
+        axis = int(_get_num_param(params, pop_node))
+        return AttrCvt(op_name="concatenate", ignores=["T", "N", "Tidx"], extras={"axis": axis})(
+            [inputs], attr
+        )
+
+    return _impl
+
+def _expand_dims():
+    def _impl(inputs, attr, params, mod):
+        dim_input = inputs.pop(1)
+        axis = _get_num_param(params, dim_input)
+        return AttrCvt(
+            op_name="expand_dims",
+            ignores=["Tdim", "N"],
+            extras={"axis": int(axis), "num_newaxis": 1},
+        )(inputs, attr)
+
+    return _impl
+
+
+
+def _tile():
+    def _impl(inputs, attr, params, mod):
+        reps_input = inputs.pop()
+        if isinstance(reps_input, _expr.Call):
+            np_reps = _infer_value(reps_input, params, mod).asnumpy()
+            reps = [np_reps.flatten()[i] for i in range(np_reps.flatten().shape[0])]
+        else:
+            reps = _get_list_param(params, reps_input)
+        new_input = [inputs.pop(0)]
+
+        return AttrCvt(op_name="tile", extras={"reps": tuple(reps)}, ignores=["Tmultiples"])(
+            new_input, attr
+        )
+
+    return _impl
+
+
+def _transpose():
+    def _impl(inputs, attr, params, mod):
+        # If perm is not specified, axes is left empty,
+        # otherwise its value is get from params
+        try:
+            axes = _get_list_param(params, inputs[1])
+        except (IndexError, KeyError, AttributeError):
+            axes = _infer_value(inputs[1], params, mod).asnumpy().tolist()
+        return _op.transpose(inputs[0], axes=axes)
+
+    return _impl
+
+def _tensorlist_reserve():
+    def _impl(inputs, attr, params, prelude):
+        dtype_str = attr.get("element_dtype").name
+        elem_shape = _infer_value(inputs[0], params, prelude.mod)
+        elem_shape = tuple(elem_shape.asnumpy().astype("int32").flatten())
+        assert -1 not in elem_shape, "TensorList size and element shape must be static"
+
+        static_tensor_array_ops = StaticTensorArrayOps(prelude, dtype_str, elem_shape)
+        static_tensor_array_ops.register()
+        tensor_array_constructor = static_tensor_array_ops.get_global_var("tensor_array")
+        tensor_array = tensor_array_constructor(inputs[1])
+        return tensor_array
+
+    return _impl
+
+def _tensorlist_set_item():
+    def _impl(inputs, attr, params, prelude):
+        dtype_str = attr.get("element_dtype").name
+        input_ta = inputs[0]
+        input_ta_shape = get_tensor_array_shape(input_ta, dtype_str, prelude)
+        input_t_shape = _infer_type_with_prelude(inputs[2], prelude).shape
+
+        static_tensor_array_ops = StaticTensorArrayOps(prelude, dtype_str, input_ta_shape)
+        static_tensor_array_ops.register()
+        tensor_func = static_tensor_array_ops.get_ctor("tensor_constructor")
+        v = tensor_func(inputs[2])
+        # Write tensor with more static shape
+        actual_shape = _get_more_static_shape(input_t_shape, input_ta_shape)
+        if actual_shape != input_t_shape:
+            new_shape = []
+            num_any_dim = 0
+            for dim in actual_shape:
+                if not isinstance(dim, int):
+                    num_any_dim += 1
+                new_shape.append(dim if isinstance(dim, int) else -1)
+            if num_any_dim <= 1:
+                v = tensor_func(_op.reshape(inputs[2], new_shape))
+        write_func = prelude.get_global_var_static(
+            "tensor_array_write", dtype_str, input_ta_shape
+        )
+        out = write_func(input_ta, inputs[1], v)
+        return out
+
+    return _impl
+
+def _tensorlist_get_item():
+    def _impl(inputs, attr, params, prelude):
+        dtype_str = attr["element_dtype"].name
+        input_shape = get_tensor_array_shape(inputs[0], dtype_str, prelude)
+
+        static_tensor_array_ops = StaticTensorArrayOps(prelude, dtype_str, input_shape)
+        static_tensor_array_ops.register()
+        read_func = static_tensor_array_ops.get_global_var("tensor_array_read")
+        out_tensor = read_func(inputs[0], _op.take(inputs[1], tvm.relay.const(0)))
+        get_data_func = static_tensor_array_ops.get_global_var("tensor_get_data")
+        out = get_data_func(out_tensor)
+        return out
+
+    return _impl
+
+def _tensorlist_stack():
+    def _impl(inputs, attr, params, prelude):
+        dtype_str = attr["element_dtype"].name
+        input_ta_shape = get_tensor_array_shape(inputs[0], dtype_str, prelude)
+        assert input_ta_shape is not None
+
+        static_tensor_array_ops = StaticTensorArrayOps(prelude, dtype_str, input_ta_shape)
+        static_tensor_array_ops.register()
+        stack_func = prelude.get_global_var_static("tensor_array_stack", dtype_str, input_ta_shape)
+        out_tensor = stack_func(inputs[0])
+        out_shape = (Any(),) + input_ta_shape
+        static_tensor_array_ops = StaticTensorArrayOps(prelude, dtype_str, out_shape)
+        static_tensor_array_ops.register()
+        get_data_func = prelude.get_global_var_static("tensor_get_data", dtype_str, out_shape)
+        out = get_data_func(out_tensor)
+
+        return out
+
+    return _impl
+
+def _tensorlist_from_tensor():
+    def _impl(inputs, attr, params, prelude):
+        dtype_str = attr["element_dtype"].name
+        input_ta_shape = _infer_type_with_prelude(inputs[0], prelude).shape
+        assert input_ta_shape is not None
+
+        static_tensor_array_ops = StaticTensorArrayOps(prelude, dtype_str, input_ta_shape)
+        static_tensor_array_ops.register()
+        unstack_func = prelude.get_global_var_static("tensor_array_unstack", dtype_str, input_ta_shape)
+        out = unstack_func(inputs[0])
+        return out
+
+    return _impl
+
+convert_map = {
+    # "Add": _elemwise("add"),
+    # "AddV2": _elemwise("add"),
+    # "BiasAdd": _bias_add(),
+
+    # "Cast": _cast(),
+    # "Conv2D": _conv("conv"),
+    # "ConcatV2": _concatV2(),
+
+    # "Equal": _broadcast("equal"),
+    # "ExpandDims": _expand_dims(),
+
+    # "Fill": _fill(),
+    # "FusedBatchNormV3": _fused_batch_norm(),
+    # "Floor": AttrCvt("floor"),
+    # "FloorMod": _floormod(),
+    # "GatherV2": _gather(),
+    # "Identity": identity(),
+    # "Less": _broadcast("less"),
+    # "LogicalAnd": _logical("logical_and"),
+    # "LogicalNot": _logical("logical_not"),
+    # "LogicalOr": _logical("logical_or"),
+
+    # "MatMul": _matmul(),
+    # "MaxPool": _pooling("max_pool"),
+    # "Maximum": _elemwise("maximum"),
+    # "Minimum": _elemwise("minimum"),
+    # "Mul": _elemwise("multiply"),
+    # "NoOp": _no_op(),
+    # "Pack": _pack(),
+
+    # "RealDiv": _elemwise("divide"),
+    # "Relu": AttrCvt("relu"),
+    # "Reshape": _reshape(),
+
+    # "Sigmoid": AttrCvt("sigmoid"),
+    # "Softmax": _softmax(),
+    # "Sub": _elemwise("subtract"),
+    # "StridedSlice": _stridedSlice(),
+    # "Shape": _shape(),
+    # "Split": _split(False),
+    # "Squeeze": _squeeze(),
+
+    # "Tanh": AttrCvt("tanh"),
+    # "Tile": _tile(),
+    # "Transpose": _transpose(),
+    # "Where": _where(),
+
+    "TensorListFromTensor": _tensorlist_from_tensor(),
+    "TensorListGetItem": _tensorlist_get_item(),
+    "TensorListReserve": _tensorlist_reserve(),
+    "TensorListSetItem": _tensorlist_set_item(),
+    "TensorListStack": _tensorlist_stack(),
+}
+
+def set_span(sym, node_name):
+    span = tvm.relay.Span(tvm.relay.SourceName(node_name), 0, 0, 0, 0)
+    if isinstance(sym, _expr.Call):
+        sym = _expr.Call(sym.op, sym.args, sym.attrs, sym.type_args, span)
+    elif isinstance(sym, _expr.TupleWrapper):
+        tuple_value = sym.tuple_value
+        if isinstance(tuple_value, _expr.Call):
+            tuple_value = _expr.Call(
+                tuple_value.op, tuple_value.args, tuple_value.attrs, tuple_value.type_args, span
+            )
+            sym = _expr.TupleWrapper(tuple_value, sym.size)
+    return sym
+
+def _get_const_value(node):
+    return node.attr["value"].tensor
+
+def convert_const_node(node):
+    """convert tf const node into relay const or var
+    """
+    tensor_value = _get_const_value(node)
+    np_array = tensor_util.MakeNdarray(tensor_value)
+
+    if np_array.dtype == np.dtype(object):
+        assert False # not tested, maybe tf string type?
+
+    if len(np_array.shape) == 0:
+        param = None
+        sym = [tvm.relay.const(np_array, np_array.dtype)]
+    else:
+        param = tvm.nd.array(np_array)
+        sym = [
+            _expr.var(node.name, shape=param.shape, dtype=param.dtype)
+        ]
+
+    return sym, param
+
+
+def get_attr(buf):
+    """convert value of a node attribute. node attribute is part of a node in a graph.
+
+        // tensorflow/core/framework/attr_value.proto
+        message AttrValue {
+            oneof value {
+                bytes s = 2;                 // "string"
+                int64 i = 3;                 // "int"
+                float f = 4;                 // "float"
+                bool b = 5;                  // "bool"
+                DataType type = 6;           // "type"
+                TensorShapeProto shape = 7;  // "shape"
+                TensorProto tensor = 8;      // "tensor"
+                ListValue list = 1;          // any "list(...)"            }
+        }        
+
+    Parameters
+    ----------
+    buf: attrvalue protobuf.  <class 'tensorflow.core.framework.attr_value_pb2.AttrValue'>
+
+    Returns
+    -------
+    The value of the attr, as a Python object.
+
+    """
+    fields = ["s", "i", "f", "b", "type", "shape", "tensor", "func"]
+
+    x = buf
+
+    ret = []
+
+    if not x.WhichOneof("value"):
+        assert False # not yet tested; why would there be empty attribute value in a node def?
+
+    if x.HasField("list"):
+        for f in fields:
+            if getattr(x.list, f):
+                if f == "type":
+                    ret += [dtypes.as_dtype(x) for x in list(getattr(x.list, f))]
+                else:
+                    ret += list(getattr(x.list, f))
+    else:
+        for f in fields:
+            if x.HasField(f):
+                if f == "type":
+                    ret = dtypes.as_dtype(getattr(x, f))
+                else:
+                    ret = getattr(x, f)
+    return ret
+    
+def parse_attr(attr_proto):
+    """Convert node attributes (a serialized map of key-value pairs) in a node to a dict
+
+    Parameters
+    ----------
+    attr_proto: <class 'google.protobuf.pyext._message.MessageMapContainer'>
+    attributes of a tf node
+
+    protobuf message format:
+        // tensorflow/core/framework/node_def.proto
+        message NodeDef {
+            map<string, AttrValue> attr = 5;
+        }
+
+    Returns
+    -------
+    Dict {string: python object}
+
+
+    Examples
+    --------
+    attributes in following node converted to {'_user_specified_name': b'x', 'dtype': tf.float32 }
+
+        node {
+        name: "x"
+        op: "Placeholder"
+        attr {
+            key: "_user_specified_name"
+            value {
+            s: "x"
+            }
+        }
+        attr {
+            key: "dtype"
+            value {
+            type: DT_FLOAT
+            }
+        }
+
+
+    """
+    attrs = {}
+    for key, value in attr_proto.items():
+        attrs[key] = get_attr(value)
+
+    return attrs
+
+def convert_place_holder(shape, node, in_type=None):
+    """ convert tf place holder into relay var. 
+    
+    Examples
+    --------    
+    a tf place holder with name "x" is converted to [Var(x, ty=TensorType([], float32))]
+
+    """
+
+    if shape and node.name in shape:
+        input_shape = list(shape[node.name])
+        assert False # not yet tested
+    else:
+        input_shape = tensor_util.TensorShapeProtoToList(
+            node.attr["shape"].shape
+        )
+        for idx, dim in enumerate(input_shape):
+            if dim < 0:
+                input_shape[idx] = Any()
+    attr = parse_attr(node.attr)
+    if in_type is not None:
+        sym = [
+            _expr.var(
+                node.name, type_annotation=in_type
+            )
+        ]
+    else:
+        sym = [
+            _expr.var(
+                node.name, shape=input_shape, dtype=attr["dtype"].name
+            )
+        ]
+    return input_shape, sym
+
+

--- a/tests/python/frontend/tensorflow/tf2/__init__.py
+++ b/tests/python/frontend/tensorflow/tf2/__init__.py
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=invalid-name, unused-argument, too-many-lines, len-as-condition, broad-except
+"""Tensorflow2.x frontend unit test. """

--- a/tests/python/frontend/tensorflow/tf2/test_common.py
+++ b/tests/python/frontend/tensorflow/tf2/test_common.py
@@ -1,0 +1,107 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=import-self, invalid-name, unused-argument, too-many-lines, len-as-condition, broad-except
+# pylint: disable=import-outside-toplevel, redefined-builtin
+"""TF2 to relay converter test utilities"""
+
+import tvm
+from tvm import relay
+
+from tvm.runtime.vm import VirtualMachine
+from tvm.contrib import graph_runtime
+from tvm.relay.frontend.tensorflow2 import from_tensorflow
+import tvm.testing
+
+def vmobj_to_list(o):
+    if isinstance(o, tvm.nd.NDArray):
+        out = o.asnumpy().tolist()
+    elif isinstance(o, tvm.runtime.container.ADT):
+        result = []
+        for f in o:
+            result.append(vmobj_to_list(f))
+        out = result
+    else:
+        raise RuntimeError("Unknown object type: %s" % type(o))
+    return out
+
+def compile(gdef, target = "llvm", target_host = "llvm", ctx = tvm.cpu(0),
+            opt_level=3, output_sig=None):
+    mod, params = from_tensorflow(gdef, outputs=output_sig)
+    with tvm.transform.PassContext(opt_level):
+        lib = relay.build(mod, target=target, target_host=target_host, params=params)
+    return graph_runtime.GraphModule(lib["default"](ctx))
+
+def compile_vm(gdef, target = "llvm", target_host = "llvm",
+               ctx = tvm.cpu(0), opt_level=3,
+               disabled_pass=None, output_sig=None):
+    mod, params = from_tensorflow(gdef, outputs=output_sig)
+    with tvm.transform.PassContext(opt_level, disabled_pass=disabled_pass):
+        mod = relay.transform.InferType()(mod)
+        vm_exec = relay.vm.compile(mod, target, target_host, params=params)
+
+    vm = VirtualMachine(vm_exec, ctx)
+    return vm
+
+def run_vm(mod, input_):
+    if type(mod) is VirtualMachine:
+        b = mod.invoke("main", input_)
+        b = vmobj_to_list(b)
+    else:
+        mod.set_input(0, input_)
+        mod.run()
+        b = mod.get_output(0).asnumpy()
+    return b
+
+def assert_allclose_array(arr1, arr2, atol=1e-3):
+    assert len(arr1) == len(arr2)
+    for val1, val2 in zip(arr1, arr2):
+        tvm.testing.assert_allclose(val1, val2, atol=atol)
+
+def compare_tf_tvm(mod, input_, out):
+    """ compare tf and tvm execution for the same input.
+
+    Parameters
+    ----------
+    func: tf function. can be from saved model or not. different ways to pass input
+        from saved model: <class 'tensorflow.python.saved_model.load._WrapperFunction'>
+        not from saved model:  <class 'tensorflow.python.eager.def_function.Function'>
+
+    mod: compiled relay module (vm or graph runtime). converted from tf func.
+
+    input_: a single numpy array object
+
+    """
+
+    b = run_vm(mod, input_)
+
+    print(f'TF: {out}')
+    print(f'TVM: {b}')
+    tvm.testing.assert_allclose(out, b, atol=1e-5)
+    print("Compare TVM/TF: Passed!")
+
+def sorted_same (a, b):
+    a = list(set(a))
+    b = list(set(b))
+    return sorted(a) == sorted(b)
+
+def run(x, vm=True, output_sig=None):
+    gdef, input_, output_ = x()
+    if vm:
+        m = compile_vm(gdef, output_sig=output_sig)
+    else:
+        m = compile(gdef, output_sig=output_sig)
+    compare_tf_tvm(m, input_, output_)

--- a/tests/python/frontend/tensorflow/tf2/test_functional.py
+++ b/tests/python/frontend/tensorflow/tf2/test_functional.py
@@ -684,12 +684,86 @@ def run_func_graph(TestClass, use_vm=False):
 
     run(_function_params, vm=use_vm)
 
-
 def run_model_graph(TestClass, output_sig=None):
     def _model_params():
         return _model_graph(TestClass)
 
     run(_model_params, vm=True, output_sig=output_sig)
+
+def run_all(TestClass):
+    run_model_graph(TestClass)
+    for use_vm in [True, False]:
+        run_func_graph(TestClass, use_vm=use_vm)
+
+
+def test_add():
+    run_all(AddOne)
+    run_all(AddOne2D)
+    run_all(AddOne2DConstant)
+
+def test_sub():
+    run_all(SubOne)
+    run_all(SubOne2D)
+    run_all(SubOne2DConstant)
+
+def test_mul():
+    run_all(MulOne)
+    run_all(MulOne2D)
+    run_all(MulOne2D_constant)
+
+def test_div():
+    run_all(DivOne)
+    run_all(DivOne2D)
+    run_all(DivOne2DConstant)
+
+def test_strided_slice():
+    run_all(StridedSlice)
+
+def test_shape():
+    run_all(Shape)
+
+def test_pack():
+    run_all(PackModel)
+
+def test_split():
+    run_all(SplitModel)
+
+def test_max():
+    run_all(Maximum)
+
+def test_less():
+    run_all(Less)
+
+def test_equal():
+    run_all(Equal)
+
+def test_floor():
+    run_all(Floor)
+    run_all(FloorMod)
+
+def test_concat_v2():
+    run_all(ConcatV2)
+
+def test_cast():
+    run_all(Cast)
+
+def test_expand_dims():
+    run_all(ExpandDims)
+
+def test_transpose():
+    run_all(Transpose)
+
+def test_reshape():
+    run_all(Reshape)
+    
+def test_tanh():
+    run_all(Tanh)
+
+def test_sigmoid():
+    run_all(Sigmoid)
+
+def test_relu():
+    run_all(Relu)
 
 def test_tensorlist():
     run_model_graph(TensorList)
@@ -721,6 +795,26 @@ def test_stateless_while_2var():
     run_model_graph(StatelessWhile2Var)
 
 if __name__ == "__main__":
+    test_add()
+    test_sub()
+    test_mul()
+    test_div()
+    test_strided_slice()
+    test_shape()
+    test_pack()
+    test_split()
+    test_max()
+    test_less()
+    test_equal()
+    test_floor()
+    test_concat_v2()
+    test_cast()
+    test_expand_dims()
+    test_transpose()
+    test_reshape()
+    test_tanh()
+    test_sigmoid()
+    test_relu()
     test_tensorlist()
     test_tensorlist_stack()
     test_tensorlist_2d()
@@ -729,35 +823,3 @@ if __name__ == "__main__":
     test_multi_output()
     test_stateless_while()
     test_stateless_while_2var()
-
-    # for test_class in [
-    #     AddOne, AddOne2D, AddOne2DConstant,
-    #     SubOne, SubOne2D, SubOne2DConstant,
-    #     MulOne, MulOne2D, MulOne2D_constant,
-    #     DivOne, DivOne2D, DivOne2DConstant,
-    #     StridedSlice, Shape, PackModel,
-    #     SplitModel, Maximum, Less, Equal, Floor,
-    #     FloorMod, ConcatV2, Cast, ExpandDims,
-    #     Transpose, Reshape,
-    #     Tanh, Sigmoid, Relu
-    # ]:
-    #     run_model_graph(test_class)
-    #     for use_vm in [True, False]:
-    #         run_func_graph(test_class, use_vm=use_vm)
-
-    # for test_class in [
-    #     # TensorList, TensorListStack,
-    #     # TensorList2D, TensorListStack2D,
-    #     TensorList2D,
-    #     If
-    # ]:
-    #     run_model_graph(test_class)
-    #     run_func_graph(test_class, use_vm=True)
-
-    # these tests require a saved graph
-    # for test_class in [
-    #     # MultiOutput,
-    #     # StatelessWhile,
-    #     StatelessWhile2Var
-    # ]:
-    #     run_model_graph(test_class, output_sig=('Identity', 'Identity_1'))

--- a/tests/python/frontend/tensorflow/tf2/test_functional.py
+++ b/tests/python/frontend/tensorflow/tf2/test_functional.py
@@ -1,0 +1,763 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=import-self, invalid-name, unused-argument, too-many-lines, len-as-condition, broad-except
+# pylint: disable=import-outside-toplevel, redefined-builtin
+"""TF2 to relay converter test: x+1 as a very basic example"""
+
+import tempfile
+import tensorflow as tf
+import numpy as np
+import pytest
+import tvm.testing
+from tvm import relay
+try:
+    from .test_common import compile, compile_vm, compare_tf_tvm, sorted_same, run
+    from .tf_helper import run_tf_code
+except:
+    from test_common import compile, compile_vm, compare_tf_tvm, sorted_same, run
+    from tf_helper import run_tf_code
+
+
+class StridedSlice(tf.Module):
+    def get_input(self):
+        return np.ones((3,2,3), dtype=np.float32)
+
+    def expected_ops(self):
+        return ['Placeholder', 'Const', 'StridedSlice', 'Identity']
+
+    def expected_lib_ops(self):
+        return ['Const', 'StridedSlice', 'Identity']
+
+    """scalar as input"""
+
+    @tf.function(input_signature=[tf.TensorSpec(shape=(3,2,3), dtype=tf.float32)])
+    def func(self, x):
+        return tf.strided_slice(x, [1, 0, 0], [2, 1, 3], [1, 1, 1])
+
+
+class Shape(tf.Module):
+    def get_input(self):
+        return np.ones((3,2,3), dtype=np.float32)
+
+    def expected_ops(self):
+        return ['Placeholder', 'Shape', 'Identity']
+
+    def expected_lib_ops(self):
+        return ['Shape', 'Identity']
+
+    """scalar as input"""
+
+    @tf.function(input_signature=[tf.TensorSpec(shape=(3, 2, 3), dtype=tf.float32)])
+    def func(self, x):
+        return tf.raw_ops.Shape(input=x)
+
+
+class PackModel(tf.Module):
+    def get_input(self):
+        return np.ones((2,3), dtype=np.float32)
+
+    def expected_ops(self):
+        return ['Placeholder', 'Pack', 'Identity']
+
+    def expected_lib_ops(self):
+        return ['Pack', 'Identity']
+
+    """scalar as input"""
+    @tf.function(input_signature=[tf.TensorSpec(shape=(2, 3), dtype=tf.float32)])
+    def func(self, x):
+        return tf.raw_ops.Pack(values=[x, x], axis=0)
+
+
+class SplitModel(tf.Module):
+    def get_input(self):
+        return np.ones((1,30), dtype=np.float32)
+
+    def expected_ops(self):
+        return ['Placeholder', 'Const', 'Split', 'Pack', 'Identity']
+
+    def expected_lib_ops(self):
+        return ['Split', 'Identity', 'Pack', 'Const']
+
+    """scalar as input"""
+    @tf.function(input_signature=[tf.TensorSpec(shape=(1, 30), dtype=tf.float32)])
+    def func(self, x):
+        a,b,c = tf.split(x, 3, axis=1)
+        return tf.raw_ops.Pack(values=[a,b,c], axis=1)
+
+
+class Maximum(tf.Module):
+    def get_input(self):
+        return np.ones((1,30), dtype=np.float32)
+
+    def expected_ops(self):
+        return ['Placeholder', 'Maximum', 'Split', 'Const', 'Identity']
+
+    def expected_lib_ops(self):
+        return ['Split', 'Identity', 'Maximum', 'Const']
+
+    """scalar as input"""
+    @tf.function(input_signature=[tf.TensorSpec(shape=(1, 30), dtype=tf.float32)])
+    def func(self, x):
+        a,b = tf.split(x, 2, axis=1)
+        return tf.math.maximum(a, b, name=None)
+
+
+class Less(tf.Module):
+    def get_input(self):
+        return np.ones((1,30), dtype=np.float32)
+
+    def expected_ops(self):
+        return ['Placeholder', 'Less', 'Split', 'Const', 'Identity']
+
+    def expected_lib_ops(self):
+        return ['Split', 'Identity', 'Less', 'Const']
+
+    """scalar as input"""
+    @tf.function(input_signature=[tf.TensorSpec(shape=(1, 30), dtype=tf.float32)])
+    def func(self, x):
+        a,b = tf.split(x, 2, axis=1)
+        return tf.math.less(a, b, name=None)
+
+
+class Equal(tf.Module):
+    def get_input(self):
+        return np.ones((1,30), dtype=np.float32)
+
+    def expected_ops(self):
+        return ['Placeholder', 'Equal', 'Split', 'Const', 'Identity']
+
+    def expected_lib_ops(self):
+        return ['Split', 'Identity', 'Equal', 'Const']
+
+    """scalar as input"""
+    @tf.function(input_signature=[tf.TensorSpec(shape=(1, 30), dtype=tf.float32)])
+    def func(self, x):
+        a,b = tf.split(x, 2, axis=1)
+        return tf.math.equal(a, b, name=None)
+
+
+
+class Cast(tf.Module):
+    def get_input(self):
+        return np.ones((1,30), dtype=np.float32)
+
+    def expected_ops(self):
+        return ['Placeholder', 'Cast', 'Identity']
+
+    def expected_lib_ops(self):
+        return ['Cast', 'Identity']
+
+    """scalar as input"""
+    @tf.function(input_signature=[tf.TensorSpec(shape=(1, 30), dtype=tf.float32)])
+    def func(self, x):
+        return tf.cast(x, tf.int32)
+
+
+class ExpandDims(tf.Module):
+    def get_input(self):
+        return np.ones((1,30), dtype=np.float32)
+
+    def expected_ops(self):
+        return ['Placeholder', 'ExpandDims', 'Identity', 'Const']
+
+    def expected_lib_ops(self):
+        return ['ExpandDims', 'Identity', 'Const']
+
+    """scalar as input"""
+    @tf.function(input_signature=[tf.TensorSpec(shape=(1, 30), dtype=tf.float32)])
+    def func(self, x):
+        return tf.expand_dims(x, axis=2)
+
+
+class Transpose(tf.Module):
+    def get_input(self):
+        return np.ones((1,30), dtype=np.float32)
+
+    def expected_ops(self):
+        return ['Placeholder', 'ExpandDims', 'Identity', 'Const', 'Transpose']
+
+    def expected_lib_ops(self):
+        return ['ExpandDims', 'Identity', 'Const', 'Transpose']
+
+    """scalar as input"""
+    @tf.function(input_signature=[tf.TensorSpec(shape=(1, 30), dtype=tf.float32)])
+    def func(self, x):
+        x = tf.expand_dims(x, axis=2)
+        return tf.transpose(x, perm=[0,2,1])
+
+
+
+class Reshape(tf.Module):
+    def get_input(self):
+        return np.ones((1,30), dtype=np.float32)
+
+    def expected_ops(self):
+        return ['Placeholder', 'Reshape', 'Identity', 'Const']
+
+    def expected_lib_ops(self):
+        return ['Identity', 'Const', 'Reshape']
+
+    """scalar as input"""
+    @tf.function(input_signature=[tf.TensorSpec(shape=(1, 30), dtype=tf.float32)])
+    def func(self, x):
+        return tf.reshape(x, (1,2,15))
+
+
+class Tanh(tf.Module):
+    def get_input(self):
+        return np.ones((1,30), dtype=np.float32)
+
+    def expected_ops(self):
+        return ['Placeholder', 'Tanh', 'Identity']
+
+    def expected_lib_ops(self):
+        return ['Tanh', 'Identity']
+
+    """scalar as input"""
+    @tf.function(input_signature=[tf.TensorSpec(shape=(1, 30), dtype=tf.float32)])
+    def func(self, x):
+        return tf.math.tanh(x)
+
+
+class Sigmoid(tf.Module):
+    def get_input(self):
+        return np.ones((1,30), dtype=np.float32)
+
+    def expected_ops(self):
+        return ['Placeholder', 'Sigmoid', 'Identity']
+
+    def expected_lib_ops(self):
+        return ['Sigmoid', 'Identity']
+
+    """scalar as input"""
+    @tf.function(input_signature=[tf.TensorSpec(shape=(1, 30), dtype=tf.float32)])
+    def func(self, x):
+        return tf.math.sigmoid(x)
+
+
+class Relu(tf.Module):
+    def get_input(self):
+        return np.ones((1,30), dtype=np.float32)
+
+    def expected_ops(self):
+        return ['Placeholder', 'Relu', 'Identity']
+
+    def expected_lib_ops(self):
+        return ['Relu', 'Identity']
+
+    """scalar as input"""
+    @tf.function(input_signature=[tf.TensorSpec(shape=(1, 30), dtype=tf.float32)])
+    def func(self, x):
+        return tf.nn.relu(x)
+
+
+
+class Floor(tf.Module):
+    def get_input(self):
+        return np.ones((1,30), dtype=np.float32)
+
+    def expected_ops(self):
+        return ['Placeholder', 'Floor', 'Identity']
+
+    def expected_lib_ops(self):
+        return ['Floor', 'Identity']
+
+    """scalar as input"""
+    @tf.function(input_signature=[tf.TensorSpec(shape=(1, 30), dtype=tf.float32)])
+    def func(self, x):
+        return tf.math.floor(x)
+
+
+class FloorMod(tf.Module):
+    def get_input(self):
+        return np.ones((1,30), dtype=np.float32)
+
+    def expected_ops(self):
+        return ['Placeholder', 'FloorMod', 'Identity', 'Split', 'Const']
+
+    def expected_lib_ops(self):
+        return ['FloorMod', 'Identity', 'Split', 'Const']
+
+    """scalar as input"""
+    @tf.function(input_signature=[tf.TensorSpec(shape=(1, 30), dtype=tf.float32)])
+    def func(self, x):
+        a, b = tf.split(x, 2, axis=1)
+        return tf.math.floormod(a, b)
+
+class ConcatV2(tf.Module):
+    def get_input(self):
+        return np.ones((1,30), dtype=np.float32)
+
+    def expected_ops(self):
+        return ['Placeholder', 'Const', 'Split', 'ConcatV2', 'Identity']
+
+    def expected_lib_ops(self):
+        return ['Split', 'Identity', 'ConcatV2', 'Const']
+
+    """scalar as input"""
+    @tf.function(input_signature=[tf.TensorSpec(shape=(1, 30), dtype=tf.float32)])
+    def func(self, x):
+        a,b,c = tf.split(x, 3, axis=1)
+        return tf.raw_ops.ConcatV2(values=[a, b, c], axis=1)
+
+class AddOne(tf.Module):
+
+    def get_input(self):
+        return np.array(1.0, dtype='float32')
+
+    def expected_ops(self):
+        return ['Placeholder', 'Const', 'AddV2', 'Identity']
+
+    def expected_lib_ops(self):
+        return ['Const', 'AddV2', 'Identity']
+
+    """scalar as input"""
+
+    @tf.function(input_signature=[tf.TensorSpec(shape=(), dtype=tf.float32)])
+    def func(self, x):
+        return x + 1
+
+
+class AddOne2D(AddOne):
+
+    def get_input(self):
+        return np.ones((2, 2), dtype='float32')
+
+    """2D array as input"""
+
+    @tf.function(input_signature=[tf.TensorSpec(shape=(2, 2), dtype=tf.float32)])
+    def func(self, x):
+        return x + 1
+
+
+class AddOne2DConstant(AddOne):
+
+    def get_input(self):
+        return np.ones((2, 2), dtype='float32')
+
+    """2D array as input with 2D constant as well; 2D constant stored in params after convert"""
+
+    @tf.function(input_signature=[tf.TensorSpec(shape=(2, 2), dtype=tf.float32)])
+    def func(self, x):
+        return x + np.ones((2, 2), dtype='float32')
+
+
+class SubOne(tf.Module):
+
+    def get_input(self):
+        return np.array(1.0, dtype='float32')
+
+    def expected_ops(self):
+        return ['Placeholder', 'Const', 'Sub', 'Identity']
+
+    def expected_lib_ops(self):
+        return ['Const', 'Sub', 'Identity']
+
+    """scalar as input"""
+
+    @tf.function(input_signature=[tf.TensorSpec(shape=(), dtype=tf.float32)])
+    def func(self, x):
+        return x - 1
+
+
+class SubOne2D(SubOne):
+
+    def get_input(self):
+        return np.ones((2, 2), dtype='float32')
+
+    """2D array as input"""
+
+    @tf.function(input_signature=[tf.TensorSpec(shape=(2, 2), dtype=tf.float32)])
+    def func(self, x):
+        return x - 1
+
+
+class SubOne2DConstant(SubOne):
+
+    def get_input(self):
+        return np.ones((2, 2), dtype='float32')
+
+    """2D array as input with 2D constant as well; 2D constant stored in params after convert"""
+
+    @tf.function(input_signature=[tf.TensorSpec(shape=(2, 2), dtype=tf.float32)])
+    def func(self, x):
+        return x - np.ones((2, 2), dtype='float32')
+
+
+class MulOne(tf.Module):
+
+    def get_input(self):
+        return np.array(1.0, dtype='float32')
+
+    def expected_ops(self):
+        return ['Placeholder', 'Const', 'Mul', 'Identity']
+
+    def expected_lib_ops(self):
+        return ['Const', 'Mul', 'Identity']
+
+    """scalar as input"""
+
+    @tf.function(input_signature=[tf.TensorSpec(shape=(), dtype=tf.float32)])
+    def func(self, x):
+        return x * 1
+
+
+class MulOne2D(MulOne):
+
+    def get_input(self):
+        return np.ones((2, 2), dtype='float32')
+
+    """2D array as input"""
+
+    @tf.function(input_signature=[tf.TensorSpec(shape=(2, 2), dtype=tf.float32)])
+    def func(self, x):
+        return x * 1
+
+
+class MulOne2D_constant(MulOne):
+
+    def get_input(self):
+        return np.ones((2, 2), dtype='float32')
+
+    """2D array as input with 2D constant as well; 2D constant stored in params after convert"""
+
+    @tf.function(input_signature=[tf.TensorSpec(shape=(2, 2), dtype=tf.float32)])
+    def func(self, x):
+        return x * np.ones((2, 2), dtype='float32')
+
+
+class DivOne(tf.Module):
+
+    def get_input(self):
+        return np.array(1.0, dtype='float32')
+
+    def expected_ops(self):
+        return ['Placeholder', 'Const', 'RealDiv', 'Identity']
+
+    def expected_lib_ops(self):
+        return ['Const', 'RealDiv', 'Identity']
+
+    """scalar as input"""
+
+    @tf.function(input_signature=[tf.TensorSpec(shape=(), dtype=tf.float32)])
+    def func(self, x):
+        return x / 1
+
+
+class DivOne2D(DivOne):
+
+    def get_input(self):
+        return np.ones((2, 2), dtype='float32')
+
+    """2D array as input"""
+
+    @tf.function(input_signature=[tf.TensorSpec(shape=(2, 2), dtype=tf.float32)])
+    def func(self, x):
+        return x / 1
+
+
+class DivOne2DConstant(DivOne):
+
+    def get_input(self):
+        return np.ones((2, 2), dtype='float32')
+
+    """2D array as input with 2D constant as well; 2D constant stored in params after convert"""
+
+    @tf.function(input_signature=[tf.TensorSpec(shape=(2, 2), dtype=tf.float32)])
+    def func(self, x):
+        return x / np.ones((2, 2), dtype='float32')
+
+
+class TensorList(tf.Module):
+    def get_input(self):
+        in_tens = np.ones((2, 3), dtype='float32')
+        in_tens[1,:] = np.zeros((3,), dtype='float32')
+        return in_tens
+
+    def expected_ops(self):
+        return ['Placeholder', 'TensorListSetItem', 'TensorListReserve', 'StridedSlice', 'TensorListGetItem', 'Identity', 'Const']
+
+    def expected_lib_ops(self):
+        return ['TensorListReserve', 'TensorListSetItem', 'TensorListGetItem', 'Const', 'StridedSlice', 'Identity']
+
+    """2D array as input"""
+    @tf.function(input_signature=[tf.TensorSpec(shape=(2, 3), dtype=tf.float32)])
+    def func(self, x):
+        elem_shape = (3,)
+        dtype = tf.float32
+        tl = tf.raw_ops.TensorListReserve(element_shape=elem_shape, num_elements=2, element_dtype=dtype)
+        tl = tf.raw_ops.TensorListSetItem(input_handle=tl, index=0, item=x[0,:])
+        tl = tf.raw_ops.TensorListSetItem(input_handle=tl, index=1, item=x[1,:])
+        output = tf.raw_ops.TensorListGetItem(input_handle=tl, index=0, element_shape=elem_shape, element_dtype=dtype)
+        return output
+
+
+class TensorList2D(TensorList):
+    def get_input(self):
+        in_tens = np.ones((2, 3, 4), dtype='float32')
+        in_tens[1,:,:] = np.zeros((3,4), dtype='float32')
+        return in_tens
+
+    """2D array as input"""
+    @tf.function(input_signature=[tf.TensorSpec(shape=(2, 3, 4), dtype=tf.float32)])
+    def func(self, x):
+        elem_shape = (3, 4)
+        dtype = tf.float32
+        tl = tf.raw_ops.TensorListReserve(element_shape=elem_shape, num_elements=2, element_dtype=dtype)
+        tl = tf.raw_ops.TensorListSetItem(input_handle=tl, index=0, item=x[0,:,:])
+        tl = tf.raw_ops.TensorListSetItem(input_handle=tl, index=1, item=x[1,:,:])
+        output = tf.raw_ops.TensorListGetItem(input_handle=tl, index=0, element_shape=elem_shape, element_dtype=dtype)
+        return output
+
+
+class TensorListStack(tf.Module):
+    def get_input(self):
+        in_tens = np.ones((2, 3), dtype='float32')
+        in_tens[1] = np.zeros((3,), dtype='float32')
+        return in_tens
+
+    def expected_ops(self):
+        return ['Const', 'TensorListFromTensor', 'Identity', 'TensorListStack', 'Placeholder', 'TensorListReserve']
+
+    def expected_lib_ops(self):
+        return ['Const', 'TensorListFromTensor', 'TensorListStack', 'Identity', 'TensorListReserve']
+
+    """2D array as input"""
+    @tf.function(input_signature=[tf.TensorSpec(shape=(2, 3), dtype=tf.float32)])
+    def func(self, x):
+        elem_shape = (3,)
+        dtype = tf.float32
+        tl = tf.raw_ops.TensorListReserve(element_shape=elem_shape, num_elements=2, element_dtype=dtype)
+        tl = tf.raw_ops.TensorListFromTensor(tensor=x, element_shape=elem_shape)
+        output = tf.raw_ops.TensorListStack(input_handle=tl, element_shape=elem_shape, element_dtype=dtype)
+        return output
+
+
+class TensorListStack2D(TensorListStack):
+    def get_input(self):
+        in_tens = np.ones((2, 3, 4), dtype='float32')
+        in_tens[1,:,:] = np.zeros((3,4), dtype='float32')
+        return in_tens
+
+    """2D array as input"""
+    @tf.function(input_signature=[tf.TensorSpec(shape=(2, 3, 4), dtype=tf.float32)])
+    def func(self, x):
+        elem_shape = (3, 4)
+        dtype = tf.float32
+        tl = tf.raw_ops.TensorListReserve(element_shape=elem_shape, num_elements=2, element_dtype=dtype)
+        tl = tf.raw_ops.TensorListFromTensor(tensor=x, element_shape=elem_shape)
+        output = tf.raw_ops.TensorListStack(input_handle=tl, element_shape=elem_shape, element_dtype=dtype)
+        return output
+
+
+class If(tf.Module):
+    def get_input(self):
+        return np.ones((2,2), dtype='float32')
+
+    def expected_ops(self):
+        return ['Placeholder', 'If', 'Identity', 'Const']
+
+    def expected_lib_ops(self):
+        return ['If', 'Identity', 'Const', 'Mul']
+
+    @tf.function(input_signature=[tf.TensorSpec(shape=(2,2), dtype=tf.float32)])
+    def func(self, x):
+        @tf.function(input_signature=[tf.TensorSpec(shape=(2,2), dtype=tf.float32)])
+        def double(x):
+            return 2*x
+
+        @tf.function(input_signature=[tf.TensorSpec(shape=(2,2), dtype=tf.float32)])
+        def triple(x):
+            return 3*x
+
+        cond = True
+        output = tf.raw_ops.If(cond=cond, input=[x], Tout=[tf.float32], output_shapes=[(2,2)],
+            then_branch=double.get_concrete_function(), else_branch=triple.get_concrete_function())
+        return output[0]
+
+
+class StatelessWhile(tf.Module):
+    def get_input(self):
+        return np.array([6], dtype='float32')
+
+    def expected_ops(self):
+        return ['Identity', 'StatelessWhile', 'Const', 'Placeholder']
+
+    def expected_lib_ops(self):
+        return ['StatelessWhile', 'Squeeze', 'Const', 'Less', 'Add', 'AddV2', 'Identity']
+
+    @tf.function(input_signature=[tf.TensorSpec(shape=(1,), dtype=tf.float32)])
+    def func(self, x):
+        i = tf.constant(3.)
+        cond = lambda i: tf.less(i, x)
+        body = lambda i: (tf.add(i, 2),)
+        r = tf.while_loop(cond, body, [i])
+        return r[0]
+
+
+class StatelessWhile2Var(StatelessWhile):
+    def get_input(self):
+        return np.array([20], dtype='float32')
+
+    @tf.function(input_signature=[tf.TensorSpec(shape=(1,), dtype=tf.float32)])
+    def func(self, x):
+        i = tf.constant(3.)
+        j = tf.constant(5.)
+        cond = lambda i,j: tf.less(i+j, x)
+        body = lambda i,j: (tf.add(i, 2), tf.add(j, 3))
+        r = tf.while_loop(cond, body, [i, j])
+        return r
+
+
+class MultiOutput(tf.Module):
+    def get_input(self):
+        return np.ones((2,2), dtype='float32')
+
+    def expected_ops(self):
+        # this case expected to fail
+        return ['Identity', 'Mul', 'Const', 'Placeholder']
+
+    def expected_lib_ops(self):
+        return ['Identity', 'Const', 'Mul']
+
+    @tf.function(input_signature=[tf.TensorSpec(shape=(2,2), dtype=tf.float32)])
+    def func(self, x):
+        y = 2*x
+        return x, y
+
+
+
+def _function_graph(TestClass):
+    f = TestClass().func
+    gdef = f.get_concrete_function().graph.as_graph_def()
+    expect_ops = TestClass().expected_ops()
+    gdef_ops = list(set([n.op for n in gdef.node]))
+    assert sorted_same(expect_ops, gdef_ops)
+    input = TestClass().get_input()
+    output = run_tf_code(f, input)
+    return gdef, input, output
+
+
+def _model_graph(TestClass):
+    model = TestClass()
+    with tempfile.TemporaryDirectory() as model_path:
+        tf.saved_model.save(model, model_path)
+        imported = tf.saved_model.load(model_path)
+
+    f = imported.signatures["serving_default"]
+    gdef = f.graph.as_graph_def(add_shapes=True)
+    gdef_ops = set([n.op for n in gdef.node])
+    expect_ops = set(['Placeholder', 'PartitionedCall', 'StatefulPartitionedCall', 'Identity'])
+    assert gdef_ops.issubset(expect_ops)
+
+    lib_ops = set()
+    for fn in gdef.library.function:
+        for n in fn.node_def:
+            lib_ops.add(n.op)
+    lib_ops = list(lib_ops)
+    expect_lib_ops = TestClass().expected_lib_ops()
+
+    assert sorted_same(expect_lib_ops, lib_ops)
+    input = model.get_input()
+    output = run_tf_code(f, input)
+
+    return gdef, input, output
+
+
+def run_func_graph(TestClass, use_vm=False):
+    def _function_params():
+        return _function_graph(TestClass)
+
+    run(_function_params, vm=use_vm)
+
+
+def run_model_graph(TestClass, output_sig=None):
+    def _model_params():
+        return _model_graph(TestClass)
+
+    run(_model_params, vm=True, output_sig=output_sig)
+
+def test_tensorlist():
+    run_model_graph(TensorList)
+    run_func_graph(TensorList, use_vm=True)
+
+def test_tensorlist_stack():
+    run_model_graph(TensorListStack)
+    run_func_graph(TensorListStack, use_vm=True)
+
+def test_tensorlist_2d():
+    run_model_graph(TensorList2D)
+    run_func_graph(TensorList2D, use_vm=True)
+
+def test_tensorlist_stack_2d():
+    run_model_graph(TensorListStack2D)
+    run_func_graph(TensorListStack2D, use_vm=True)
+
+def test_if():
+    run_model_graph(If)
+    run_func_graph(If, use_vm=True)
+
+def test_multi_output():
+    run_model_graph(MultiOutput)
+
+def test_stateless_while():
+    run_model_graph(StatelessWhile)
+
+def test_stateless_while_2var():
+    run_model_graph(StatelessWhile2Var)
+
+if __name__ == "__main__":
+    test_tensorlist()
+    test_tensorlist_stack()
+    test_tensorlist_2d()
+    test_tensorlist_stack_2d()
+    test_if()
+    test_multi_output()
+    test_stateless_while()
+    test_stateless_while_2var()
+
+    # for test_class in [
+    #     AddOne, AddOne2D, AddOne2DConstant,
+    #     SubOne, SubOne2D, SubOne2DConstant,
+    #     MulOne, MulOne2D, MulOne2D_constant,
+    #     DivOne, DivOne2D, DivOne2DConstant,
+    #     StridedSlice, Shape, PackModel,
+    #     SplitModel, Maximum, Less, Equal, Floor,
+    #     FloorMod, ConcatV2, Cast, ExpandDims,
+    #     Transpose, Reshape,
+    #     Tanh, Sigmoid, Relu
+    # ]:
+    #     run_model_graph(test_class)
+    #     for use_vm in [True, False]:
+    #         run_func_graph(test_class, use_vm=use_vm)
+
+    # for test_class in [
+    #     # TensorList, TensorListStack,
+    #     # TensorList2D, TensorListStack2D,
+    #     TensorList2D,
+    #     If
+    # ]:
+    #     run_model_graph(test_class)
+    #     run_func_graph(test_class, use_vm=True)
+
+    # these tests require a saved graph
+    # for test_class in [
+    #     # MultiOutput,
+    #     # StatelessWhile,
+    #     StatelessWhile2Var
+    # ]:
+    #     run_model_graph(test_class, output_sig=('Identity', 'Identity_1'))

--- a/tests/python/frontend/tensorflow/tf2/test_sequential.py
+++ b/tests/python/frontend/tensorflow/tf2/test_sequential.py
@@ -1,0 +1,243 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=import-self, invalid-name, unused-argument, too-many-lines, len-as-condition, broad-except
+# pylint: disable=import-outside-toplevel, redefined-builtin
+"""TF2 to relay converter test: x+1 as a very basic example"""
+
+import tempfile
+import numpy as np
+import pytest
+import tensorflow as tf
+from tensorflow.python.framework.convert_to_constants \
+    import convert_variables_to_constants_v2
+
+from test_common import sorted_same, run
+from tf_helper import run_tf_code
+
+class TensorArrayStackLayer(tf.keras.layers.Layer):
+    def __init__(self, name="tensor_array_test"):
+        super().__init__(name=name)
+
+    def call(self, inputs):
+        inputs = tf.squeeze(inputs)
+        outputs = tf.TensorArray(tf.float32, size=inputs.shape[0],
+            infer_shape=False, element_shape=inputs.shape[1:])
+        outputs = outputs.unstack(inputs)
+
+        return outputs.stack()
+
+class TensorArrayReadLayer(tf.keras.layers.Layer):
+    def __init__(self, name="tensor_array_test"):
+        super().__init__(name=name)
+
+    def call(self, inputs):
+        inputs = tf.squeeze(inputs)
+        outputs = tf.TensorArray(tf.float32, size=inputs.shape[0],
+            infer_shape=False, element_shape=inputs.shape[1:])
+        for i in range(inputs.shape[0]):
+            outputs = outputs.write(i, inputs[i,:])
+
+        return outputs.read(0)
+
+class SequentialModels:
+    def __init__(self):
+        self.input_shape = (1, 28, 28)
+        self.shape = (self.input_shape[1], self.input_shape[2])
+
+    def get_model(self, key, freeze=True):
+        if key == "dense":
+            return self.dense_model()
+        elif key == "mnist":
+            return self.mnist_model()
+        elif key == "conv2d":
+            return self.conv2d_model()
+        elif key == "max_pool":
+            return self.maxpool_model()
+        elif key == "batch_norm":
+            return self.batchnorm_model()
+        elif key == "tensorlist_stack":
+            return self.tensorlist_model(stack=True)
+        elif key == "tensorlist_read":
+            return self.tensorlist_model(stack=False)
+        else:
+            assert False
+
+    def save_and_reload(self, model):
+        with tempfile.TemporaryDirectory() as model_path:
+            tf.saved_model.save(model, model_path)
+            loaded = tf.saved_model.load(model_path)
+            func = loaded.signatures["serving_default"]
+            frozen_func = convert_variables_to_constants_v2(func)
+        return frozen_func
+
+    def freeze(self, model):
+        # Convert the seq model to tf function
+        f = tf.function(model).get_concrete_function(
+            tf.TensorSpec(model.inputs[0].shape, model.inputs[0].dtype))
+        frozen_func = convert_variables_to_constants_v2(f)
+        return frozen_func
+
+    def reshape_model(self, freeze=True):
+        model = tf.keras.Sequential(
+            [
+                tf.keras.layers.Flatten(input_shape=self.shape),
+            ]
+        )
+        if freeze:
+            exp_ops = ['Placeholder', 'Const', 'Reshape', 'Identity']
+        else:
+            exp_ops = ['Placeholder', 'Const', 'Reshape']
+        return model, exp_ops
+
+    def tensorlist_model(self, stack=False):
+        self.input_shape = (1, 3, 32)
+        self.shape = (3, 32)
+        if stack:
+            model = tf.keras.Sequential(
+                [
+                    tf.keras.layers.Input(shape=self.shape, batch_size=1),
+                    TensorArrayStackLayer()
+                ]
+            )
+            exp_ops = ['Placeholder', 'TensorListStack', 'Identity', 'Squeeze', 'Const', 'TensorListFromTensor']
+            return model, exp_ops
+        else:
+            model = tf.keras.Sequential(
+                [
+                    tf.keras.layers.Input(shape=self.shape, batch_size=1),
+                    TensorArrayReadLayer()
+                ]
+            )
+            exp_ops = ['TensorListSetItem', 'Const', 'Placeholder', 'StridedSlice', 'Squeeze', 'Identity', 'TensorListReserve', 'TensorListGetItem']
+            return model, exp_ops
+
+    def dense_model(self):
+        model = tf.keras.Sequential(
+            [
+                tf.keras.layers.Flatten(input_shape=self.shape),
+                tf.keras.layers.Dense(4)
+            ]
+        )
+        exp_ops = ['Placeholder', 'Const', 'Reshape', 'MatMul', 'BiasAdd', 'Identity']
+        return model, exp_ops
+
+    def mnist_model(self):
+        model = tf.keras.Sequential([
+            tf.keras.layers.Flatten(input_shape=(28, 28)),
+            tf.keras.layers.Dense(128, activation="relu"),
+            tf.keras.layers.Dense(10)
+        ])
+
+        exp_ops = ['Placeholder', 'Const', 'Reshape', 'MatMul', 'BiasAdd', 'Identity', 'Relu']
+        return model, exp_ops
+
+    def conv2d_model(self):
+        filters = 16
+        kernel = (3, 3)
+        self.input_shape = (1, 32, 32, 3)
+        model = tf.keras.Sequential([
+            tf.keras.layers.Input(shape=(32, 32, 3), batch_size=1),
+            tf.keras.layers.Conv2D(filters, kernel)
+        ])
+
+        exp_ops = ['Placeholder', 'Const', 'Conv2D', 'BiasAdd', 'Identity']
+        return model, exp_ops
+
+    def maxpool_model(self):
+        self.input_shape = (1, 32, 32, 3)
+        model = tf.keras.Sequential([
+            tf.keras.layers.MaxPool2D(pool_size=(2, 2), input_shape=self.input_shape[1:])
+        ])
+
+        exp_ops = ['Placeholder', 'Identity', 'MaxPool']
+        return model, exp_ops
+
+
+    def batchnorm_model(self):
+
+        self.input_shape = (1, 32, 32, 3)
+        model = tf.keras.Sequential([
+            tf.keras.layers.MaxPool2D(pool_size=(2,2), input_shape=self.input_shape[1:]),
+            tf.keras.layers.BatchNormalization()
+        ])
+
+        exp_ops = ['Placeholder', 'Identity', 'Const', 'FusedBatchNormV3', 'MaxPool']
+        return model, exp_ops
+
+
+def test_sequential_model(key, mode="freeze"):
+    def check_op_coverage(gdef, expected_ops):
+        gdef_ops = list(set([n.op for n in gdef.node]))
+        if 'NoOp' in gdef_ops:
+            gdef_ops.remove('NoOp')
+        assert sorted_same(expected_ops, gdef_ops)
+
+    def get_input(shape):
+        input = np.random.uniform(0,1,shape).astype(dtype='float32')
+        return input
+
+    def function_params_seq_nofreeze():
+        g = tf.Graph()
+        model = SequentialModels()
+        with g.as_default():
+            f, expected_ops = model.get_model(key, freeze=False)
+        input = get_input(model.input_shape)
+        output = run_tf_code(f, input)
+        gdef = g.as_graph_def()
+        check_op_coverage(gdef, expected_ops)
+        return gdef, input, output
+
+    def function_params_seq_freeze():
+        model = SequentialModels()
+        seq, expected_ops = model.get_model(key, freeze=True)
+        f = model.freeze(seq)
+        input = get_input(model.input_shape)
+        output = run_tf_code(f, input)
+        gdef = f.graph.as_graph_def()
+        check_op_coverage(gdef, expected_ops)
+        return gdef, input, output
+
+    def model_graph():
+        model = SequentialModels()
+        seq, expected_ops = model.get_model(key)
+        input = get_input(model.input_shape)
+        f = model.save_and_reload(seq)
+        output = run_tf_code(f, input)
+        gdef = f.graph.as_graph_def(add_shapes=True)
+        check_op_coverage(gdef, expected_ops)
+        return gdef, input, output
+
+    if mode == "freeze":
+        run(function_params_seq_freeze)
+    elif mode == "nofreeze":
+        run(function_params_seq_nofreeze)
+    elif mode == "reload":
+        run(model_graph)
+    else:
+        assert False
+
+if __name__ == "__main__":
+
+    for mode in ["freeze", "reload"]:
+        test_sequential_model("dense", mode=mode)
+        test_sequential_model("mnist", mode=mode)
+        test_sequential_model("max_pool", mode=mode)
+        test_sequential_model("batch_norm", mode=mode)
+        test_sequential_model("conv2d", mode=mode)
+
+        test_sequential_model("tensorlist_stack", mode=mode)
+        test_sequential_model("tensorlist_read", mode=mode)

--- a/tests/python/frontend/tensorflow/tf2/tf_helper.py
+++ b/tests/python/frontend/tensorflow/tf2/tf_helper.py
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# pylint: disable=import-self, invalid-name, unused-argument, too-many-lines, len-as-condition, broad-except
+# pylint: disable=import-outside-toplevel, redefined-builtin
+"""TF2 to relay converter test utilities"""
+
+
+import tensorflow as tf
+from tensorflow.python.eager.def_function import Function
+
+def run_tf_code(func, input_):
+    if type(func) is Function:
+        out = func(input_)
+        if isinstance(out, list):
+            a = [x.numpy() for x in out]
+        else:
+            a = out.numpy()
+    else:
+        a = func(tf.constant(input_))
+        if type(a) is dict:
+            a = [x.numpy() for x in a.values()]
+            if len(a) == 1:
+                a = a[0]
+        elif type(a) is list:
+            a = [x.numpy() for x in a]
+            if len(a) == 1:
+                a = a[0]
+        else:
+            a = a.numpy()
+    return a
+


### PR DESCRIPTION
This PR adds an alternative from_tensorflow() function supporting TF2 tensorlists and control flow ops. Work and discussion regarding upstream apache/tvm changes are ongoing as it's an extensive change. This is intended to be a stopgap solution to  support several TF2 models in the short term.