### PR TITLE
Workaround to enable select ops in TRT explicit batch mode

### DIFF
--- a/python/tvm/relay/op/contrib/tensorrt.py
+++ b/python/tvm/relay/op/contrib/tensorrt.py
@@ -177,9 +177,18 @@ def check_dynamism(args, op_name):
     """
     for arg in args:
         if isinstance(arg, (Call, Var, Constant, TupleGetItem)):
-            for dim_shape in arg.checked_type.shape[1:]:
-                if isinstance(dim_shape, tvm.tir.expr.Any):
-                    return True
+            if (
+                op_name not in ["nn.conv2d", "nn.conv2d_transpose", "nn.dense"]
+                and not get_tensorrt_use_implicit_batch_mode()
+            ):
+                # Explicit batch mode doesn't support any dynamic shapes yet, except for conv2d
+                for dim_shape in arg.checked_type.shape:
+                    if isinstance(dim_shape, tvm.tir.expr.Any):
+                        return True
+            else:
+                for dim_shape in arg.checked_type.shape[1:]:
+                    if isinstance(dim_shape, tvm.tir.expr.Any):
+                        return True
         elif isinstance(arg, Tuple):
             return check_dynamism(arg.fields, op_name)
         else:


### PR DESCRIPTION
Cherry-picking this change from 1.9.1 back to mainline until a proper fix is added to address the root cause